### PR TITLE
Set retention time to 0 so the slave is immediately reaped JENKINS-31197

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -91,5 +91,5 @@ public class ECSSlave extends AbstractCloudSlave {
         }
     }
 
-    private final static RetentionStrategy  ONCE = new CloudRetentionStrategy(1);
+    private final static RetentionStrategy  ONCE = new CloudRetentionStrategy(0);
 }


### PR DESCRIPTION
According to https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java the max idle time doesn't have to be a minimum of 1 minute

For builds which churn a lot & have a very low idle time a CloudRetentionStrategy(1) will mean that a container is potentially reused instead of destroyed at the end of each build, which is one of the intentions of this plugin (containers aren't reused)

Jenkins throws a few EOF exceptions, but it appears to work

Wouldn't mind a bit of review as to why it was set to 1 minute?