### PR TITLE
Added privilege mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.16</version>
+      <version>1.10.26</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -102,16 +102,21 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      */
     @CheckForNull
     private String jvmArgs;
+    /**
+     * Indicates whether the container should run in privileged mode
+     */
+    private final boolean privileged;
 
     private String taskDefinitionArn;
 
     @DataBoundConstructor
-    public ECSTaskTemplate(@Nullable String label, @Nonnull String image, @Nullable String remoteFSRoot, int memory, int cpu) {
+    public ECSTaskTemplate(@Nullable String label, @Nonnull String image, @Nullable String remoteFSRoot, int memory, int cpu, boolean privileged) {
         this.label = label;
         this.image = image;
         this.remoteFSRoot = remoteFSRoot;
         this.memory = memory;
         this.cpu = cpu;
+        this.privileged = privileged;
     }
 
     @DataBoundSetter
@@ -169,7 +174,8 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
                 .withName("jenkins-slave")
                 .withImage(image)
                 .withMemory(memory)
-                .withCpu(cpu);
+                .withCpu(cpu)
+                .withPrivileged(privileged);
         if (entrypoint != null)
             def.withEntryPoint(StringUtils.split(entrypoint));
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -156,6 +156,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     public String getJvmArgs() {
         return jvmArgs;
     }
+    
+    public boolean getPrivileged() {
+        return privileged;
+    }
 
     public String getTaskDefinitionArn() {
         return taskDefinitionArn;

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -47,5 +47,8 @@
     <f:entry title="${%JVM arguments}" field="jvmArgs">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Privileged}" field="privileged">
+      <f:checkbox />
+    </f:entry>
   </f:advanced>
 </j:jelly>


### PR DESCRIPTION
These changes allows to configure the container to be run in [privileged](https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration) mode.

