### PR TITLE
[JENKINS-32321] catch task missing exceptions

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -35,6 +35,7 @@ import com.amazonaws.services.ecs.model.RunTaskRequest;
 import com.amazonaws.services.ecs.model.RunTaskResult;
 import com.amazonaws.services.ecs.model.StopTaskRequest;
 import com.amazonaws.services.ecs.model.TaskOverride;
+import com.amazonaws.services.ecs.model.ClientException;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -202,7 +203,11 @@ public class ECSCloud extends Cloud {
         final AmazonECSClient client = getAmazonECSClient(credentialsId, getRegionName());
 
         LOGGER.log(Level.INFO, "Delete ECS Slave task: {0}", taskArn);
-        client.stopTask(new StopTaskRequest().withTask(taskArn));
+        try {
+            client.stopTask(new StopTaskRequest().withTask(taskArn));
+        } catch (ClientException e) {
+            LOGGER.log(Level.SEVERE, "Couldn't stop task arn " + taskArn + " caught exception: " + e.getMessage(), e);
+        }
     }
 
     private class ProvisioningCallback implements Callable<Node> {


### PR DESCRIPTION
This is a proposed fix to https://issues.jenkins-ci.org/browse/JENKINS-32321

The call to AWS to delete an ECS task is wrapped in a try catch because in some cases (either legitimate or not) the task doesn't exist.

If not caught then there's some ugly behaviour where the exception will prevent Jenkins from starting or stop you from saving configurations in the UI