### PR TITLE
[JENKINS-32740] Make retention strategy timeout configurable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -50,6 +50,8 @@ import hudson.security.ACL;
 import hudson.slaves.Cloud;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.NodeProvisioner;
+import hudson.slaves.CloudRetentionStrategy;
+import hudson.slaves.RetentionStrategy;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
@@ -92,13 +94,22 @@ public class ECSCloud extends Cloud {
     @CheckForNull
     private String tunnel;
 
+    /** Default timeout for idle workers that don't correctly indicate exit. */
+    private static final int DEFAULT_RETENTION_TIMEOUT_MINUTES = 5;
+    private final int retentionTimeout;
+
     @DataBoundConstructor
-    public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, String cluster, String regionName) {
+    public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, String cluster, String regionName, int retentionTimeout) {
         super(name);
         this.credentialsId = credentialsId;
         this.cluster = cluster;
         this.templates = templates;
         this.regionName = regionName;
+        if (retentionTimeout > 0) {
+            this.retentionTimeout = retentionTimeout;
+        } else {
+            this.retentionTimeout = DEFAULT_RETENTION_TIMEOUT_MINUTES;
+        }
         if (templates != null) {
             for (ECSTaskTemplate template : templates) {
                 template.setOwer(this);
@@ -133,6 +144,10 @@ public class ECSCloud extends Cloud {
     @DataBoundSetter
     public void setTunnel(String tunnel) {
         this.tunnel = tunnel;
+    }
+
+    public int getRetentionTimeout() {
+        return retentionTimeout;
     }
 
     @CheckForNull
@@ -229,7 +244,8 @@ public class ECSCloud extends Cloud {
         public Node call() throws Exception {
 
             String uniq = Long.toHexString(System.nanoTime());
-            ECSSlave slave = new ECSSlave(ECSCloud.this, name + "-" + uniq, template.getRemoteFSRoot(), label == null ? null : label.toString(), new JNLPLauncher());
+            RetentionStrategy retentionStrategy = new CloudRetentionStrategy(getRetentionTimeout());
+            ECSSlave slave = new ECSSlave(ECSCloud.this, name + "-" + uniq, template.getRemoteFSRoot(), label == null ? null : label.toString(), new JNLPLauncher(), retentionStrategy);
             Jenkins.getInstance().addNode(slave);
             LOGGER.log(Level.INFO, "Created Slave: {0}", slave.getNodeName());
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -58,8 +58,8 @@ public class ECSSlave extends AbstractCloudSlave {
     @CheckForNull
     private String taskArn;
 
-    public ECSSlave(@Nonnull ECSCloud cloud, @Nonnull String name, @Nullable String remoteFS, @Nullable String labelString, @Nonnull ComputerLauncher launcher) throws Descriptor.FormException, IOException {
-        super(name, "ECS slave", remoteFS, 1, Mode.EXCLUSIVE, labelString, launcher, RetentionStrategy.NOOP, Collections.EMPTY_LIST);
+    public ECSSlave(@Nonnull ECSCloud cloud, @Nonnull String name, @Nullable String remoteFS, @Nullable String labelString, @Nonnull ComputerLauncher launcher, @Nonnull RetentionStrategy retentionStrategy) throws Descriptor.FormException, IOException {
+        super(name, "ECS slave", remoteFS, 1, Mode.EXCLUSIVE, labelString, launcher, retentionStrategy, Collections.EMPTY_LIST);
         this.cloud = cloud;
     }
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -46,6 +46,9 @@
       <f:textbox />
     </f:entry>
 
+    <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout" description="Timeout in mins for a Slave instance to live">
+      <f:textbox default="5"/>
+    </f:entry>
   </f:advanced>
 
   <f:entry title="${%ECS slave templates}">


### PR DESCRIPTION
The following puts the CloudRetentionStrategy back so that Jenkins can reap a slave which is no longer or was never connected.

Without having a retention strategy of some sort any slaves which are created but cannot have an ECS task associated with them never get removed by the cleanup thread in Jenkins which normally looks after Cloud based slaves.

Timeout defaults to 5 mins (which should give enough time to docker pull etc.)