### PR TITLE
[JENKINS-32741] Allow the log driver to be set for a Task

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -34,6 +34,7 @@ import com.amazonaws.services.ecs.model.MountPoint;
 import com.amazonaws.services.ecs.model.KeyValuePair;
 import com.amazonaws.services.ecs.model.RegisterTaskDefinitionRequest;
 import com.amazonaws.services.ecs.model.RegisterTaskDefinitionResult;
+import com.amazonaws.services.ecs.model.LogConfiguration;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -50,6 +51,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -123,6 +126,26 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     private String taskDefinitionArn;
 
+    /**
+    * The log configuration specification for the container.
+    * This parameter maps to LogConfig in the Create a container section of
+    * the Docker Remote API and the --log-driver option to docker run.
+    * Valid log drivers are displayed in the LogConfiguration data type.
+    * This parameter requires version 1.18 of the Docker Remote API or greater
+    * on your container instance. To check the Docker Remote API version on
+    * your container instance, log into your container instance and run the
+    * following command: sudo docker version | grep "Server API version"
+    * The Amazon ECS container agent running on a container instance must
+    * register the logging drivers available on that instance with the
+    * ECS_AVAILABLE_LOGGING_DRIVERS environment variable before containers
+    * placed on that instance can use these log configuration options.
+    * For more information, see Amazon ECS Container Agent Configuration
+    * in the Amazon EC2 Container Service Developer Guide.
+    */
+    @CheckForNull
+    private String logDriver;
+    private List<LogDriverOption> logDriverOptions;
+
     @DataBoundConstructor
     public ECSTaskTemplate(@Nullable String label,
                            @Nonnull String image,
@@ -130,6 +153,8 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
                            int memory,
                            int cpu,
                            boolean privileged,
+                           @Nullable List<LogDriverOption> logDriverOptions,
+                           @Nullable String logDriver,
                            @Nullable List<EnvironmentEntry> environments,
                            @Nullable List<ExtraHostEntry> extraHosts,
                            @Nullable List<MountPointEntry> mountPoints) {
@@ -139,6 +164,8 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         this.memory = memory;
         this.cpu = cpu;
         this.privileged = privileged;
+        this.logDriver = logDriver;
+        this.logDriverOptions = logDriverOptions;
         this.environments = environments;
         this.extraHosts = extraHosts;
         this.mountPoints = mountPoints;
@@ -184,6 +211,53 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     public boolean getPrivileged() {
         return privileged;
+    }
+
+    public String getLogDriver() {
+        return logDriver;
+    }
+
+    public static class LogDriverOption extends AbstractDescribableImpl<LogDriverOption>{
+        public String name, value;
+
+        @DataBoundConstructor
+        public LogDriverOption(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return "LogDriverOption{" + name + ": " + value + "}";
+        }
+
+        @Extension
+        public static class DescriptorImpl extends Descriptor<LogDriverOption> {
+            @Override
+            public String getDisplayName() {
+                return "logDriverOption";
+            }
+        }
+    }
+
+    public List<LogDriverOption> getLogDriverOptions() {
+        return logDriverOptions;
+    }
+
+    private Map<String,String> getLogDriverOptionsMap() {
+        if (null == logDriverOptions || logDriverOptions.isEmpty()) {
+            return null;
+        }
+        Map<String,String> options = new HashMap<String,String>();
+        for (LogDriverOption logDriverOption : logDriverOptions) {
+            String name = logDriverOption.name;
+            String value = logDriverOption.value;
+            if (StringUtils.isEmpty(name) || StringUtils.isEmpty(value)) {
+                continue;
+            }
+            options.put(name, value);
+        }
+        return options;
     }
 
     public String getTaskDefinitionArn() {
@@ -372,6 +446,13 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
             def.withEnvironment(new KeyValuePair()
                 .withName("JAVA_OPTS").withValue(jvmArgs))
                 .withEssential(true);
+
+        if (logDriver != null) {
+            LogConfiguration logConfig = new LogConfiguration();
+            logConfig.setLogDriver(logDriver);
+            logConfig.setOptions(getLogDriverOptionsMap());
+            def.withLogConfiguration(logConfig);
+        }
 
         return new RegisterTaskDefinitionRequest()
             .withFamily("jenkins-slave")

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -50,6 +50,26 @@
     <f:entry title="${%Privileged}" field="privileged">
       <f:checkbox />
     </f:entry>
+    <f:entry title="${%Logging Driver}" field="logDriver">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Logging Configuration}">
+      <f:repeatable field="logDriverOptions">
+        <table width="100%">
+          <f:entry title="${%Name}" field="name">
+            <f:textbox />
+          </f:entry>
+          <f:entry title="${%Value}" field="value">
+            <f:textbox />
+          </f:entry>
+          <f:entry>
+            <div align="right">
+              <f:repeatableDeleteButton />
+            </div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
     <f:entry title="${%Environments}">
       <f:repeatable field="environments">
         <table width="100%">


### PR DESCRIPTION
This PR allows the log driver to be set on a Task to something other than the default of JSON

If you're keen you can switch to the syslog driver & then pull logs from the EC2 boxes which are backing the ECS cluster so that you can see what the Jenkins Remoting Slave Jar is up to (or not up to if it's crashing, OOMing, or otherwise misbehaving)