### PR TITLE
[JENKINS-32895] Supply cluster ARN when stopping tasks

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -204,12 +204,12 @@ public class ECSCloud extends Cloud {
         return client;
     }
 
-    void deleteTask(String taskArn) {
+    void deleteTask(String taskArn, String clusterArn) {
         final AmazonECSClient client = getAmazonECSClient();
 
         LOGGER.log(Level.INFO, "Delete ECS Slave task: {0}", taskArn);
         try {
-            client.stopTask(new StopTaskRequest().withTask(taskArn));
+            client.stopTask(new StopTaskRequest().withTask(taskArn).withCluster(clusterArn));
         } catch (ClientException e) {
             LOGGER.log(Level.SEVERE, "Couldn't stop task arn " + taskArn + " caught exception: " + e.getMessage(), e);
         }
@@ -234,6 +234,8 @@ public class ECSCloud extends Cloud {
             LOGGER.log(Level.INFO, "Created Slave: {0}", slave.getNodeName());
 
             final AmazonECSClient client = getAmazonECSClient();
+
+            slave.setClusterArn(cluster);
 
             Collection<String> command = getDockerRunCommand(slave);
             String definitionArn = template.getTaskDefinitionArn();

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -49,6 +49,10 @@ public class ECSSlave extends AbstractCloudSlave {
     private final ECSCloud cloud;
 
     /**
+     * AWS Resource Name (ARN) of the ECS Cluster.
+     */
+    private String clusterArn;
+    /**
      * AWS Resource Name (ARN) of the ECS Task Definition.
      */
     private String taskDefinitonArn;
@@ -63,12 +67,20 @@ public class ECSSlave extends AbstractCloudSlave {
         this.cloud = cloud;
     }
 
+    public String getClusterArn() {
+        return clusterArn;
+    }
+
     public String getTaskDefinitonArn() {
         return taskDefinitonArn;
     }
 
     public String getTaskArn() {
         return taskArn;
+    }
+
+    void setClusterArn(String clusterArn) {
+        this.clusterArn = clusterArn;
     }
 
     void setTaskArn(String taskArn) {
@@ -87,7 +99,7 @@ public class ECSSlave extends AbstractCloudSlave {
     @Override
     protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
         if (taskArn != null) {
-            cloud.deleteTask(taskArn);
+            cloud.deleteTask(taskArn, clusterArn);
         }
     }
 


### PR DESCRIPTION
The ECS API assumes the default cluster for stopping a task unless otherwise specified. This patch specifies the cluster for all StopTask requests.

Fixes [JENKINS-32895](https://issues.jenkins-ci.org/browse/JENKINS-32895)