### PR TITLE
Updates the ECSTaskTemplate to properly set logDriver to null when empty

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -154,7 +154,6 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
                            int cpu,
                            boolean privileged,
                            @Nullable List<LogDriverOption> logDriverOptions,
-                           @Nullable String logDriver,
                            @Nullable List<EnvironmentEntry> environments,
                            @Nullable List<ExtraHostEntry> extraHosts,
                            @Nullable List<MountPointEntry> mountPoints) {
@@ -164,7 +163,6 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         this.memory = memory;
         this.cpu = cpu;
         this.privileged = privileged;
-        this.logDriver = logDriver;
         this.logDriverOptions = logDriverOptions;
         this.environments = environments;
         this.extraHosts = extraHosts;
@@ -179,6 +177,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     @DataBoundSetter
     public void setJvmArgs(String jvmArgs) {
         this.jvmArgs = StringUtils.trimToNull(jvmArgs);
+    }
+
+    @DataBoundSetter
+    public void setLogDriver(String logDriver) {
+        this.logDriver = StringUtils.trimToNull(logDriver);
     }
 
     public String getLabel() {


### PR DESCRIPTION
This PR updates the `ECSTaskTemplate` to set the logDriver using the `@DataBoundSetter ` annotation.  A guard on the input parameter ensures that the logDriver is null... not just empty. :wink:  These changes address a small bug introduced in commit @65880c7b and merged into master in PR #16.  

PR #16 updates the amazon-ecs plugin with the ability to set the log Driver for the ECS Task.  However, when the logging driver is left empty, the following errors occur:

![image](https://cloud.githubusercontent.com/assets/2084797/14476369/57beaffe-00d5-11e6-926a-b3500c6c3aaa.png)


``` bash
Caused by: java.lang.RuntimeException: Failed to instantiate class com.cloudbees.jenkins.plugins.amazonecs.ECSCloud from {"name":"some-cloud","credentialsId":"f02646c5-368a-4845-a157-fa67a07f3d1d","regionName":"us-east-1","cluster":"arn:aws:ecs:us-east-1:xxxxxxxxxx:cluster/test-cluster","tunnel":"","templates":{"label":"simple-test","image":"jenkinsci/jnlp-slave","remoteFSRoot":"/home/jenkins","memory":"512","cpu":"1","entrypoint":"","jvmArgs":"","privileged":false,"logDriver":""},"stapler-class":"com.cloudbees.jenkins.plugins.amazonecs.ECSCloud","$class":"com.cloudbees.jenkins.plugins.amazonecs.ECSCloud"}
	at hudson.model.Descriptor.newInstance(Descriptor.java:600)
	at hudson.model.Descriptor.newInstancesFromHeteroList(Descriptor.java:1034)
	at hudson.model.Descriptor.newInstancesFromHeteroList(Descriptor.java:996)
	at hudson.util.DescribableList.rebuildHetero(DescribableList.java:208)
	at jenkins.model.GlobalCloudConfiguration.configure(GlobalCloudConfiguration.java:23)
	at jenkins.model.Jenkins.configureDescriptor(Jenkins.java:2965)
	at jenkins.model.Jenkins.doConfigSubmit(Jenkins.java:2928)
	... 69 more
Caused by: com.amazonaws.services.ecs.model.ClientException: logConfiguration.logDriver must not be blank (Service: AmazonECS; Status Code: 400; Error Code: ClientException; Request ID: bcdf3004-0017-11e6-85a9-ef988787879c)
	at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:1275)
	at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:873)
	at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:576)
	at com.amazonaws.http.AmazonHttpClient.doExecute(AmazonHttpClient.java:362)
	at com.amazonaws.http.AmazonHttpClient.executeWithTimer(AmazonHttpClient.java:328)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:307)
```

These changes make the `logDriver` consistent with other optional settings.