### PR TITLE
Alternative Jenkins URL for callback from cloud slaves

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
   <groupId>com.cloudbees.jenkins.plugins</groupId>
   <artifactId>amazon-ecs</artifactId>
-  <version>1.2</version>
+  <version>1.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Amazon EC2 Container Service plugin</name>
   <description>Jenkins plugin to run dynamic slaves in a Amazon ECS/Docker environment</description>
@@ -54,7 +54,7 @@
     <connection>scm:git:git://github.com/jenkinsci/amazon-ecs-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/amazon-ecs-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/amazon-ecs-plugin</url>
-    <tag>amazon-ecs-1.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -96,7 +96,7 @@ public class ECSCloud extends Cloud {
     
     private String jenkinsUrl;
 
-    @DataBoundConstructor
+	@DataBoundConstructor
     public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, 
     		String cluster, String regionName, String jenkinsUrl) {
         super(name);
@@ -229,7 +229,7 @@ public class ECSCloud extends Cloud {
 
         LOGGER.log(Level.INFO, "Delete ECS Slave task: {0}", taskArn);
         try {
-            client.stopTask(new StopTaskRequest().withTask(taskArn));
+            client.stopTask(new StopTaskRequest().withTask(taskArn).withCluster(cluster));
         } catch (ClientException e) {
             LOGGER.log(Level.SEVERE, "Couldn't stop task arn " + taskArn + " caught exception: " + e.getMessage(), e);
         }
@@ -371,5 +371,12 @@ public class ECSCloud extends Cloud {
             return Region.getRegion(Regions.US_EAST_1);
         }
     }
+    
+    public String getJenkinsUrl() {
+		return jenkinsUrl;
+	}
 
+	public void setJenkinsUrl(String jenkinsUrl) {
+		this.jenkinsUrl = jenkinsUrl;
+	}
 }


### PR DESCRIPTION
With this change one can supply an alternative Jenkins Urls the cloud slave uses to callback to Jenkins. This can be useful when combined with the tunnel option to enable slaves which call back to the master over a dedicated connection.