### PR TITLE
Alternative Jenkins URL for callback from cloud slaves

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -93,9 +93,12 @@ public class ECSCloud extends Cloud {
      */
     @CheckForNull
     private String tunnel;
+    
+    private String jenkinsUrl;
 
     @DataBoundConstructor
-    public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, String cluster, String regionName) {
+    public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, 
+    		String cluster, String regionName, String jenkinsUrl) {
         super(name);
         this.credentialsId = credentialsId;
         this.cluster = cluster;
@@ -105,6 +108,11 @@ public class ECSCloud extends Cloud {
             for (ECSTaskTemplate template : templates) {
                 template.setOwer(this);
             }
+        }
+        if(StringUtils.isNotBlank(jenkinsUrl)) {
+        	this.jenkinsUrl = jenkinsUrl;
+        } else {
+        	this.jenkinsUrl = JenkinsLocationConfiguration.get().getUrl();
         }
     }
 
@@ -300,7 +308,7 @@ public class ECSCloud extends Cloud {
     private Collection<String> getDockerRunCommand(ECSSlave slave) {
         Collection<String> command = new ArrayList<String>();
         command.add("-url");
-        command.add(JenkinsLocationConfiguration.get().getUrl());
+        command.add(jenkinsUrl);
         if (StringUtils.isNotBlank(tunnel)) {
             command.add("-tunnel");
             command.add(tunnel);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -96,7 +96,7 @@ public class ECSCloud extends Cloud {
     
     private String jenkinsUrl;
 
-    @DataBoundConstructor
+	@DataBoundConstructor
     public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, 
     		String cluster, String regionName, String jenkinsUrl) {
         super(name);
@@ -373,5 +373,12 @@ public class ECSCloud extends Cloud {
             return Region.getRegion(Regions.US_EAST_1);
         }
     }
+    
+    public String getJenkinsUrl() {
+		return jenkinsUrl;
+	}
 
+	public void setJenkinsUrl(String jenkinsUrl) {
+		this.jenkinsUrl = jenkinsUrl;
+	}
 }

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -45,7 +45,10 @@
     <f:entry field="tunnel" title="${%Tunnel connection through}" help="/help/system-config/master-slave/jnlp-tunnel.html">
       <f:textbox />
     </f:entry>
-
+    
+    <f:entry field="jenkinsUrl" title="${%Alternative Jenkins URL}" description="If needed, the Jenkins URL can be overwritten with this property (e.g. to support other HTTP(S) endpoints due to reverse proxies or firewalling). By default the URL from the global Jenkins configuration is used.">
+      <f:textbox />
+    </f:entry>
   </f:advanced>
 
   <f:entry title="${%ECS slave templates}">


### PR DESCRIPTION
With this change one can supply an alternative Jenkins Urls the cloud slave uses to callback to Jenkins. This can be useful when combined with the tunnel option to enable slaves which call back to the master over a dedicated connection.