### PR TITLE
Add the ability to link existing ECS tasks

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -70,6 +70,25 @@
         </table>
       </f:repeatable>
     </f:entry>
+
+    <f:entry title="${%Linked Tasks}">
+      <f:repeatable field="linkedTasks">
+        <table width="100%">
+          <f:entry title="${%Name}" field="name">
+            <f:textbox value="${instance.name}" />
+          </f:entry>
+          <f:entry title="${%Revision}" field="revision">
+            <f:textbox value="${instance.revision}" />
+          </f:entry>
+          <f:entry>
+            <div align="right">
+              <f:repeatableDeleteButton />
+            </div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+
     <f:entry title="${%Environments}">
       <f:repeatable field="environments">
         <table width="100%">

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -146,5 +146,23 @@
         </table>
       </f:repeatable>
     </f:entry>
+
+    <f:entry title="${%Volumes From}">
+      <f:repeatable field="volumesFrom">
+        <table width="100%">
+          <f:entry title="${%Source Container}" field="sourceContainer">
+            <f:textbox value="${instance.sourceContainer}" />
+          </f:entry>
+          <f:entry title="${%Read Only}" field="readOnly">
+            <f:checkbox />
+          </f:entry>
+          <f:entry>
+            <div align="right">
+              <f:repeatableDeleteButton />
+            </div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
   </f:advanced>
 </j:jelly>


### PR DESCRIPTION
- Task definitions are managed using ECS
  - Task definitions can be locked to a specific revision (default latest)
  - The obvious disadvantage is, when changes are made to the ECS tasks,
    the ECSTaskTemplate must be updated manually
- The tasks' container definitions are copied to the new task definition
  - Each container will be linked to the new container definition
  - Each port mapping's host port will be set to 0 (random assignment)
- All volumes, defined in ECS tasks, will be copied to the new task
- Add ability to mount volumes from other containers
## Use case

I am running jenkins slaves, which are performing selenium grid tests. The good people at selenium have provided the community with composable containers... But, because of ECSs irrational need to rename containers, it's very difficult to use jnlp-slave with selenium-hub and selenium-chrome images.
## Rationale

I need parallel jenkins slaves for selenium testing. It seems like the effort required to support every option in the ECS API, from this plugin, is a daunting task. I certainly don't have the bandwidth to tackle it... This seems like the next best option. Consider it a very temporary kludge?

A major drawback to this approach is the asynchronous updates which must be maintained. If you update an included task, in the AWS console, you have to remember to save your configuration in Jenkins.

Another disappointment is the way I passed around the `client`. Since ECSTaskTemplate is `Describable`, the object is serialized, and I don't know how to prevent fields from being serialized... So the object is passed around like a hot potato. 
