### PR TITLE
Scalability improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-credentials</artifactId>
-      <version>1.10</version>
+      <version>1.15</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -25,21 +25,34 @@
 
 package com.cloudbees.jenkins.plugins.amazonecs;
 
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.ecs.AmazonECSClient;
-import com.amazonaws.services.ecs.model.ClientException;
-import com.amazonaws.services.ecs.model.ContainerOverride;
-import com.amazonaws.services.ecs.model.Failure;
-import com.amazonaws.services.ecs.model.RunTaskRequest;
-import com.amazonaws.services.ecs.model.RunTaskResult;
-import com.amazonaws.services.ecs.model.StopTaskRequest;
-import com.amazonaws.services.ecs.model.TaskOverride;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.Computer;
@@ -53,27 +66,16 @@ import hudson.slaves.NodeProvisioner;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
-import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.QueryParameter;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ECSCloud extends Cloud {
-
+	
+	private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
+	
+	private static final int DEFAULT_SLAVE_TIMEOUT = 900;
+		
     private final List<ECSTaskTemplate> templates;
 
     /**
@@ -92,8 +94,15 @@ public class ECSCloud extends Cloud {
     @CheckForNull
     private String tunnel;
 
-    @DataBoundConstructor
-    public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, String cluster, String regionName) {
+    private String jenkinsUrl;
+        
+    private int slaveTimoutInSeconds;
+        
+    private ECSService ecsService;
+    
+	@DataBoundConstructor
+    public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, 
+    		String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds) {
         super(name);
         this.credentialsId = credentialsId;
         this.cluster = cluster;
@@ -104,7 +113,30 @@ public class ECSCloud extends Cloud {
                 template.setOwer(this);
             }
         }
+        
+        if(StringUtils.isNotBlank(jenkinsUrl)) {
+        	this.jenkinsUrl = jenkinsUrl;
+        } else {
+        	this.jenkinsUrl = JenkinsLocationConfiguration.get().getUrl();
+        }
+
+        if(slaveTimoutInSeconds > 0) {
+        	this.slaveTimoutInSeconds = slaveTimoutInSeconds;
+        } else {
+        	this.slaveTimoutInSeconds = DEFAULT_SLAVE_TIMEOUT;
+        }
     }
+
+	synchronized ECSService getEcsService() {
+		if (ecsService == null) {
+			ecsService = new ECSService(credentialsId, regionName);
+		}
+		return ecsService;
+	}
+
+	AmazonECSClient getAmazonECSClient() {
+		return getEcsService().getAmazonECSClient();
+	}
 
     public List<ECSTaskTemplate> getTemplates() {
         return templates;
@@ -180,10 +212,6 @@ public class ECSCloud extends Cloud {
         }
     }
 
-    /* package */ AmazonECSClient getAmazonECSClient() {
-        return getAmazonECSClient(credentialsId, regionName);
-    }
-
     private static AmazonECSClient getAmazonECSClient(String credentialsId, String regionName) {
         final AmazonECSClient client;
         AmazonWebServicesCredentials credentials = getCredentials(credentialsId);
@@ -204,16 +232,22 @@ public class ECSCloud extends Cloud {
         return client;
     }
 
-    void deleteTask(String taskArn) {
-        final AmazonECSClient client = getAmazonECSClient();
+	void deleteTask(String taskArn, String clusterArn) {
+		getEcsService().deleteTask(taskArn, clusterArn);
+	}
+	
+	public void setJenkinsUrl(String jenkinsUrl) {
+		this.jenkinsUrl = jenkinsUrl;
+	}
 
-        LOGGER.log(Level.INFO, "Delete ECS Slave task: {0}", taskArn);
-        try {
-            client.stopTask(new StopTaskRequest().withTask(taskArn));
-        } catch (ClientException e) {
-            LOGGER.log(Level.SEVERE, "Couldn't stop task arn " + taskArn + " caught exception: " + e.getMessage(), e);
-        }
-    }
+	public int getSlaveTimoutInSeconds() {
+		return slaveTimoutInSeconds;
+	}
+
+	public void setSlaveTimoutInSeconds(int slaveTimoutInSeconds) {
+		this.slaveTimoutInSeconds = slaveTimoutInSeconds;
+	}
+
 
     private class ProvisioningCallback implements Callable<Node> {
 
@@ -226,67 +260,67 @@ public class ECSCloud extends Cloud {
             this.label = label;
         }
 
-        public Node call() throws Exception {
+		public Node call() throws Exception {
+			final ECSSlave slave;
 
-            String uniq = Long.toHexString(System.nanoTime());
-            ECSSlave slave = new ECSSlave(ECSCloud.this, name + "-" + uniq, template.getRemoteFSRoot(), label == null ? null : label.toString(), new JNLPLauncher());
-            Jenkins.getInstance().addNode(slave);
-            LOGGER.log(Level.INFO, "Created Slave: {0}", slave.getNodeName());
+			Date now = new Date();
+			Date timeout = new Date(now.getTime() + 1000 * slaveTimoutInSeconds);
 
-            final AmazonECSClient client = getAmazonECSClient();
+			synchronized (cluster) {
+				getEcsService().waitForSufficientClusterResources(timeout, template, cluster);
 
-            Collection<String> command = getDockerRunCommand(slave);
-            String definitionArn = template.getTaskDefinitionArn();
-            slave.setTaskDefinitonArn(definitionArn);
+				String uniq = Long.toHexString(System.nanoTime());
+				slave = new ECSSlave(ECSCloud.this, name + "-" + uniq, template.getRemoteFSRoot(),
+						label == null ? null : label.toString(), new JNLPLauncher());
+				slave.setClusterArn(cluster);
+				Jenkins.getInstance().addNode(slave);
+				while (Jenkins.getInstance().getNode(slave.getNodeName()) == null) {
+					Thread.sleep(1000);
+				}
+				LOGGER.log(Level.INFO, "Created Slave: {0}", slave.getNodeName());
 
-            final RunTaskResult runTaskResult = client.runTask(new RunTaskRequest()
-              .withTaskDefinition(definitionArn)
-              .withOverrides(new TaskOverride()
-                .withContainerOverrides(new ContainerOverride()
-                  .withName("jenkins-slave")
-                  .withCommand(command)))
-              .withCluster(cluster)
-            );
+				try {
+					String taskArn = getEcsService().runEcsTask(slave, template, cluster, getDockerRunCommand(slave));
+					LOGGER.log(Level.INFO, "Slave {0} - Slave Task Started : {1}",
+							new Object[] { slave.getNodeName(), taskArn });
+					slave.setTaskArn(taskArn);
+				} catch (AbortException ex) {
+					Jenkins.getInstance().removeNode(slave);
+					throw ex;
+				}
+			}
 
-            if (!runTaskResult.getFailures().isEmpty()) {
-                LOGGER.log(Level.WARNING, "Slave {0} - Failure to run task with definition {1} on ECS cluster {2}", new Object[]{slave.getNodeName(), definitionArn, cluster});
-                for (Failure failure : runTaskResult.getFailures()) {
-                    LOGGER.log(Level.WARNING, "Slave {0} - Failure reason={1}, arn={2}", new Object[]{slave.getNodeName(), failure.getReason(), failure.getArn()});
-                }
-                throw new AbortException("Failed to run slave container " + slave.getNodeName());
-            }
+			// now wait for slave to be online
+			while (timeout.after(new Date())) {
+				if (slave.getComputer() == null) {
+					throw new IllegalStateException(
+							"Slave " + slave.getNodeName() + " - Node was deleted, computer is null");
+				}
+				if (slave.getComputer().isOnline()) {
+					break;
+				}
+				LOGGER.log(Level.FINE, "Waiting for slave {0} (ecs task {1}) to connect since {2}.",
+						new Object[] { slave.getNodeName(), slave.getTaskArn(), now });
+				Thread.sleep(1000);
+			}
+			if (!slave.getComputer().isOnline()) {
+				final String msg = MessageFormat.format("ECS Slave {0} (ecs task {1}) not connected since {2} seconds",
+						slave.getNodeName(), slave.getTaskArn(), now);
+				LOGGER.log(Level.WARNING, msg);
+				Jenkins.getInstance().removeNode(slave);
+				throw new IllegalStateException(msg);
+			}
 
-            String taskArn = runTaskResult.getTasks().get(0).getTaskArn();
-            LOGGER.log(Level.INFO, "Slave {0} - Slave Task Started : {1}", new Object[]{slave.getNodeName(), taskArn});
-            slave.setTaskArn(taskArn);
-
-            int i = 0;
-            int j = 100; // wait 100 seconds
-
-            // now wait for slave to be online
-            for (; i < j; i++) {
-                if (slave.getComputer() == null) {
-                    throw new IllegalStateException("Slave " + slave.getNodeName() + " - Node was deleted, computer is null");
-                }
-                if (slave.getComputer().isOnline()) {
-                    break;
-                }
-                LOGGER.log(Level.FINE, "Waiting for slave {0} (ecs task {1}) to connect ({2}/{3}).", new Object[]{slave.getNodeName(), taskArn, i, j});
-                Thread.sleep(1000);
-            }
-            if (!slave.getComputer().isOnline()) {
-                throw new IllegalStateException("ECS Slave " + slave.getNodeName() + " (ecs task " + taskArn + ") is not connected after " + j + " seconds");
-            }
-
-            LOGGER.log(Level.INFO, "ECS Slave " + slave.getNodeName() + " (ecs task {0}) connected", taskArn);
-            return slave;
-        }
-    }
+			LOGGER.log(Level.INFO, "ECS Slave " + slave.getNodeName() + " (ecs task {0}) connected",
+					slave.getTaskArn());
+			return slave;
+		}
+	}
 
     private Collection<String> getDockerRunCommand(ECSSlave slave) {
         Collection<String> command = new ArrayList<String>();
         command.add("-url");
-        command.add(JenkinsLocationConfiguration.get().getUrl());
+        command.add(jenkinsUrl);
         if (StringUtils.isNotBlank(tunnel)) {
             command.add("-tunnel");
             command.add(tunnel);
@@ -325,9 +359,9 @@ public class ECSCloud extends Cloud {
         }
 
         public ListBoxModel doFillClusterItems(@QueryParameter String credentialsId, @QueryParameter String regionName) {
-            try {
-                final AmazonECSClient client = getAmazonECSClient(credentialsId, regionName);
-
+        	ECSService ecsService = new ECSService(credentialsId, regionName);
+        	try {
+        	    final AmazonECSClient client = ecsService.getAmazonECSClient();
                 final ListBoxModel options = new ListBoxModel();
                 for (String arn : client.listClusters().getClusterArns()) {
                     options.add(arn);
@@ -341,8 +375,6 @@ public class ECSCloud extends Cloud {
         }
 
     }
-
-    private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
 
     public static Region getRegion(String regionName) {
         if (StringUtils.isNotEmpty(regionName)) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -1,0 +1,177 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.ecs.AmazonECSClient;
+import com.amazonaws.services.ecs.model.ClientException;
+import com.amazonaws.services.ecs.model.ContainerInstance;
+import com.amazonaws.services.ecs.model.ContainerOverride;
+import com.amazonaws.services.ecs.model.DescribeContainerInstancesRequest;
+import com.amazonaws.services.ecs.model.DescribeContainerInstancesResult;
+import com.amazonaws.services.ecs.model.Failure;
+import com.amazonaws.services.ecs.model.ListContainerInstancesRequest;
+import com.amazonaws.services.ecs.model.ListContainerInstancesResult;
+import com.amazonaws.services.ecs.model.Resource;
+import com.amazonaws.services.ecs.model.RunTaskRequest;
+import com.amazonaws.services.ecs.model.RunTaskResult;
+import com.amazonaws.services.ecs.model.StopTaskRequest;
+import com.amazonaws.services.ecs.model.TaskOverride;
+import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
+import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
+
+import hudson.AbortException;
+import hudson.ProxyConfiguration;
+import jenkins.model.Jenkins;
+
+/**
+ * Encapsulates interactions with Amazon ECS.
+ * 
+ * @author Jan Roehrich <jan@roehrich.info>
+ *
+ */
+class ECSService {
+    private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
+    
+    private String credentialsId;
+    
+    private String regionName;
+	
+    public ECSService(String credentialsId, String regionName) {
+		super();
+		this.credentialsId = credentialsId;
+		this.regionName = regionName;
+	}
+
+	AmazonECSClient getAmazonECSClient() {
+        final AmazonECSClient client;
+        
+        ProxyConfiguration proxy = Jenkins.getInstance().proxy;
+        ClientConfiguration clientConfiguration = new ClientConfiguration();            
+        if(proxy != null) {
+        	clientConfiguration.setProxyHost(proxy.name);
+        	clientConfiguration.setProxyPort(proxy.port);
+        	clientConfiguration.setProxyUsername(proxy.getUserName());
+        	clientConfiguration.setProxyPassword(proxy.getPassword());
+        }
+        
+        AmazonWebServicesCredentials credentials = getCredentials(credentialsId);
+        if (credentials == null) {
+            // no credentials provided, rely on com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+            // to use IAM Role define at the EC2 instance level ...
+            client = new AmazonECSClient(clientConfiguration);
+        } else {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                String awsAccessKeyId = credentials.getCredentials().getAWSAccessKeyId();
+                String obfuscatedAccessKeyId = StringUtils.left(awsAccessKeyId, 4) + StringUtils.repeat("*", awsAccessKeyId.length() - (2 * 4)) + StringUtils.right(awsAccessKeyId, 4);
+                LOGGER.log(Level.FINE, "Connect to Amazon ECS with IAM Access Key {1}", new Object[]{obfuscatedAccessKeyId});
+            }
+            client = new AmazonECSClient(credentials, clientConfiguration);
+        }
+        client.setRegion(getRegion(regionName));
+        LOGGER.log(Level.FINE, "Selected Region: {0}", regionName);
+        return client;
+    }
+    
+    Region getRegion(String regionName) {
+        if (StringUtils.isNotEmpty(regionName)) {
+            return RegionUtils.getRegion(regionName);
+        } else {
+            return Region.getRegion(Regions.US_EAST_1);
+        }
+    }
+    
+    @CheckForNull
+    private AmazonWebServicesCredentials getCredentials(@Nullable String credentialsId) {
+        return AWSCredentialsHelper.getCredentials(credentialsId, Jenkins.getActiveInstance());
+    }
+    
+    void deleteTask(String taskArn, String clusterArn) {
+        final AmazonECSClient client = getAmazonECSClient();
+
+        LOGGER.log(Level.INFO, "Delete ECS Slave task: {0}", taskArn);
+        try {
+            client.stopTask(new StopTaskRequest().withTask(taskArn).withCluster(clusterArn));
+        } catch (ClientException e) {
+            LOGGER.log(Level.SEVERE, "Couldn't stop task arn " + taskArn + " caught exception: " + e.getMessage(), e);
+        }
+    }
+    
+	String runEcsTask(final ECSSlave slave, final ECSTaskTemplate template, String clusterArn, Collection<String> command) throws IOException, AbortException {
+		AmazonECSClient client = getAmazonECSClient();
+		String definitionArn = template.getTaskDefinitionArn();
+		slave.setTaskDefinitonArn(definitionArn);	            
+		    
+		final RunTaskResult runTaskResult = client.runTask(new RunTaskRequest()
+		  .withTaskDefinition(definitionArn)
+		  .withOverrides(new TaskOverride()
+		    .withContainerOverrides(new ContainerOverride()
+		      .withName("jenkins-slave")
+		      .withCommand(command)))
+		  .withCluster(clusterArn)
+		);
+
+		if (!runTaskResult.getFailures().isEmpty()) {
+		    LOGGER.log(Level.WARNING, "Slave {0} - Failure to run task with definition {1} on ECS cluster {2}", new Object[]{slave.getNodeName(), definitionArn, clusterArn});
+		    for (Failure failure : runTaskResult.getFailures()) {
+		        LOGGER.log(Level.WARNING, "Slave {0} - Failure reason={1}, arn={2}", new Object[]{slave.getNodeName(), failure.getReason(), failure.getArn()});
+		    }			    
+		    throw new AbortException("Failed to run slave container " + slave.getNodeName());
+		}
+		return runTaskResult.getTasks().get(0).getTaskArn();            
+	}
+	
+	void waitForSufficientClusterResources(Date timeout, ECSTaskTemplate template, String clusterArn) throws InterruptedException, AbortException {
+		AmazonECSClient client = getAmazonECSClient();
+		
+		boolean hasEnoughResources = false;			
+		WHILE:
+		do {
+			ListContainerInstancesResult listContainerInstances = client.listContainerInstances(new ListContainerInstancesRequest().withCluster(clusterArn));
+			DescribeContainerInstancesResult containerInstancesDesc = client.describeContainerInstances(new DescribeContainerInstancesRequest().withContainerInstances(listContainerInstances.getContainerInstanceArns()).withCluster(clusterArn));
+			LOGGER.log(Level.INFO, "Found {0} instances", containerInstancesDesc.getContainerInstances().size());
+			for(ContainerInstance instance : containerInstancesDesc.getContainerInstances()) {
+				LOGGER.log(Level.INFO, "Resources found in instance {1}: {0}", new Object[] {instance.getRemainingResources(), instance.getContainerInstanceArn()});
+				Resource memoryResource = null;
+				Resource cpuResource = null;
+				for(Resource resource : instance.getRemainingResources()) {
+					if("MEMORY".equals(resource.getName())) {
+						memoryResource = resource;
+					} else if("CPU".equals(resource.getName())) {
+						cpuResource = resource;
+					}        					
+				}
+				
+				LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemory()});
+				LOGGER.log(Level.INFO, "Instance {0} has {1} units of free cpu. {2} units are required", new Object[]{ instance.getContainerInstanceArn(), cpuResource.getIntegerValue(), template.getCpu()});
+				if(memoryResource.getIntegerValue() >= template.getMemory() 
+						&& cpuResource.getIntegerValue() >= template.getCpu()) {
+					hasEnoughResources = true;
+					break WHILE;
+				}
+			}
+			
+			// sleep 10s and check memory again
+			Thread.sleep(10000);
+		} while(!hasEnoughResources && timeout.after(new Date()));
+		
+		if(!hasEnoughResources) {
+			final String msg = MessageFormat.format("Timeout while waiting for sufficient resources: {0} cpu units, {1}mb free memory", template.getCpu(), template.getMemory());
+		    LOGGER.log(Level.WARNING, msg);
+		    throw new AbortException(msg);
+		}
+	}
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -25,20 +25,19 @@
 
 package com.cloudbees.jenkins.plugins.amazonecs;
 
-import hudson.model.Descriptor;
-import hudson.model.Node;
-import hudson.model.TaskListener;
-import hudson.slaves.AbstractCloudComputer;
-import hudson.slaves.AbstractCloudSlave;
-import hudson.slaves.CloudRetentionStrategy;
-import hudson.slaves.ComputerLauncher;
-import hudson.slaves.RetentionStrategy;
+import java.io.IOException;
+import java.util.Collections;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.Collections;
+
+import hudson.model.Descriptor;
+import hudson.model.TaskListener;
+import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.RetentionStrategy;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -57,6 +56,13 @@ public class ECSSlave extends AbstractCloudSlave {
      */
     @CheckForNull
     private String taskArn;
+    
+	/**
+	 * The ARN of the cluster in AWS. The first cluster ever created in AWS is
+	 * considered the default one by Amazon. This field is needed to always
+	 * choose the correct cluster.
+	 */
+	private String clusterArn;
 
     public ECSSlave(@Nonnull ECSCloud cloud, @Nonnull String name, @Nullable String remoteFS, @Nullable String labelString, @Nonnull ComputerLauncher launcher) throws Descriptor.FormException, IOException {
         super(name, "ECS slave", remoteFS, 1, Mode.EXCLUSIVE, labelString, launcher, RetentionStrategy.NOOP, Collections.EMPTY_LIST);
@@ -87,8 +93,16 @@ public class ECSSlave extends AbstractCloudSlave {
     @Override
     protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
         if (taskArn != null) {
-            cloud.deleteTask(taskArn);
+            cloud.deleteTask(taskArn, clusterArn);
         }
     }
+
+	public String getClusterArn() {
+		return clusterArn;
+	}
+
+	public void setClusterArn(String clusterArn) {
+		this.clusterArn = clusterArn;
+	}
 
 }


### PR DESCRIPTION
* make the provisioner wait for sufficient cluster resources before creating tasks. This avoids failed tasks resulting in stale Jenkins slaves.
* make the slave timeout configurable
* gracefully remove a slave from Jenkins in case of task startup
   failure
* use the cluster ARN to communicate with AWS to avoid letting Amazon choose the default cluster
* refactor ECSCloud to move AWS related stuff to a separate class