### PR TITLE
Deregister task definitions on save

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -106,9 +106,8 @@ public class ECSCloud extends Cloud {
         this.templates = templates;
         this.regionName = regionName;
         if (templates != null) {
-            //Delete the existing task definitions before setting new ones.
-            //This is necessary as every save creates a task definition and
-            //they will grow and grow.
+            //Deregister the existing task definitions before setting new ones.
+            //This is necessary as every save creates a task definition.
             ECSTaskTemplate.deregisterAllTaskDefinitions(this);
             for (ECSTaskTemplate template : templates) {
                 template.setOwer(this);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -106,6 +106,10 @@ public class ECSCloud extends Cloud {
         this.templates = templates;
         this.regionName = regionName;
         if (templates != null) {
+            //Delete the existing task definitions before setting new ones.
+            //This is necessary as every save creates a task definition and
+            //they will grow and grow.
+            ECSTaskTemplate.deregisterAllTaskDefinitions(this);
             for (ECSTaskTemplate template : templates) {
                 template.setOwer(this);
             }


### PR DESCRIPTION
Hi

I've noticed that every time you save the configuration via the console a new Task definition gets created. This happens irrespective of whether you are creating/updating a new task and causes the number of active tasks to just grow and grow. 

This request will deregister all existing tasks listed under the 'jenkins-slave' family before saving the new set. This way we will only have those tasks that are active in view in the aws console and stop active tasks from just hanging around needlessly.

Thanks
