### PR TITLE
Don't provision if label is null

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -186,8 +186,11 @@ public class ECSCloud extends Cloud {
     }
 
     private ECSTaskTemplate getTemplate(Label label) {
+        if (label == null) {
+            return null;
+        }
         for (ECSTaskTemplate t : templates) {
-            if (label == null || label.matches(t.getLabelSet())) {
+            if (label.matches(t.getLabelSet())) {
                 return t;
             }
         }


### PR DESCRIPTION
Creating ECSSlave with null label is wasting of resource, because ECSSlave
is instantiate with EXCLUSIVE mode. Job with null label will not
scheduled to it
It's even worse, it will keep trying to create more idle ECSSlave and
consume all resource in cluster :(


How to reproduce this problem:
- Make sure that amazon ecs plugin is the only one agent that active (by setting master executor number to 0, disable other cloud, ..., etc)
- Create a template (just use jenkinsci/jnlp-slave image) with arbitary label (or without label)
- Create simple job (without label) and run it
- BOOM!!, ecs plugin will keep trying to create ecs task and the job will not scheduled to any those agent because the agent is exclusive

right now, the only way to prevent this from happening is to make sure that every job have label