### PR TITLE
Add taskRoleArn configuration option. Update aws-sdk dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.28</version>
+      <version>1.11.37</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.45</version>
+      <version>1.11.28</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -106,6 +106,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     @CheckForNull
     private String entrypoint;
     /**
+     * ARN of the IAM role to use for the slave ECS task
+     */
+    @CheckForNull
+    private String taskRoleArn;
+    /**
       JVM arguments to start slave.jar
      */
     @CheckForNull
@@ -170,6 +175,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     }
 
     @DataBoundSetter
+    public void setTaskRoleArn(String taskRoleArn) {
+        this.taskRoleArn = StringUtils.trimToNull(taskRoleArn);
+    }
+
+    @DataBoundSetter
     public void setEntrypoint(String entrypoint) {
         this.entrypoint = StringUtils.trimToNull(entrypoint);
     }
@@ -206,6 +216,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     public String getEntrypoint() {
         return entrypoint;
+    }
+
+    public String getTaskRoleArn() {
+        return taskRoleArn;
     }
 
     public String getJvmArgs() {
@@ -460,7 +474,8 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         return new RegisterTaskDefinitionRequest()
             .withFamily("jenkins-slave")
             .withVolumes(getVolumeEntries())
-            .withContainerDefinitions(def);
+            .withContainerDefinitions(def)
+            .withTaskRoleArn(taskRoleArn);
     }
 
     public void setOwer(ECSCloud owner) {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -41,6 +41,9 @@
     <f:textbox default="1"/>
   </f:entry>
   <f:advanced>
+    <f:entry title="${%ECS Task Role ARN}" field="taskRoleArn">
+      <f:textbox />
+    </f:entry>
     <f:entry title="${%Override entrypoint}" field="entrypoint">
       <f:textbox />
     </f:entry>


### PR DESCRIPTION
This will add the possibility to assign an IAM role to the slave ECS task definition.
To do this I needed to update the dependency to the newer AWS SDK, because adding a task role is not supported in the old version.
Please merge only after the aws-java-sdk plugin is available in version 1.11.28.
