### PR TITLE
Change how node removal work

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -72,11 +72,11 @@ import jenkins.model.JenkinsLocationConfiguration;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ECSCloud extends Cloud {
-	
+
 	private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
-	
+
 	private static final int DEFAULT_SLAVE_TIMEOUT = 900;
-		
+
     private final List<ECSTaskTemplate> templates;
 
     /**
@@ -96,13 +96,13 @@ public class ECSCloud extends Cloud {
     private String tunnel;
 
     private String jenkinsUrl;
-        
+
     private int slaveTimoutInSeconds;
-        
+
     private ECSService ecsService;
-    
+
 	@DataBoundConstructor
-    public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId, 
+    public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId,
     		String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds) throws InterruptedException{
         super(name);
         this.credentialsId = credentialsId;
@@ -122,7 +122,7 @@ public class ECSCloud extends Cloud {
                 }
             }
         }
-        
+
         if(StringUtils.isNotBlank(jenkinsUrl)) {
         	this.jenkinsUrl = jenkinsUrl;
         } else {
@@ -267,6 +267,7 @@ public class ECSCloud extends Cloud {
 							new Object[] { slave.getNodeName(), taskArn });
 					slave.setTaskArn(taskArn);
 				} catch (Exception ex) {
+					LOGGER.log(Level.WARNING, "Slave {0} - Cannot create ECS Task");
 					Jenkins.getInstance().removeNode(slave);
 					throw ex;
 				}
@@ -315,7 +316,7 @@ public class ECSCloud extends Cloud {
 
     @Extension
     public static class DescriptorImpl extends Descriptor<Cloud> {
-    	
+
     	private static String CLOUD_NAME_PATTERN = "[a-z|A-Z|0-9|_|-]{1,127}";
 
         @Override
@@ -371,7 +372,7 @@ public class ECSCloud extends Cloud {
             return Region.getRegion(Regions.US_EAST_1);
         }
     }
-    
+
 	public String getJenkinsUrl() {
 		return jenkinsUrl;
 	}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -55,7 +55,6 @@ import com.amazonaws.services.ecs.AmazonECSClient;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 
-import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -267,7 +266,7 @@ public class ECSCloud extends Cloud {
 					LOGGER.log(Level.INFO, "Slave {0} - Slave Task Started : {1}",
 							new Object[] { slave.getNodeName(), taskArn });
 					slave.setTaskArn(taskArn);
-				} catch (AbortException ex) {
+				} catch (Exception ex) {
 					Jenkins.getInstance().removeNode(slave);
 					throw ex;
 				}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputer.java
@@ -37,6 +37,7 @@ import java.io.IOException;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ECSComputer extends AbstractCloudComputer {
+
     public ECSComputer(ECSSlave slave) {
         super(slave);
     }
@@ -58,10 +59,6 @@ public class ECSComputer extends AbstractCloudComputer {
      */
     private void terminate() {
         setAcceptingTasks(false);
-        try {
-            getNode().terminate();
-        } catch (InterruptedException e) {
-        } catch (IOException e) {
-        }
     }
+
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -64,35 +64,35 @@ import jenkins.model.Jenkins;
 
 /**
  * Encapsulates interactions with Amazon ECS.
- * 
+ *
  * @author Jan Roehrich <jan@roehrich.info>
  *
  */
 class ECSService {
     private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
-    
-    private String credentialsId;
-    
-    private String regionName;
-	
-    public ECSService(String credentialsId, String regionName) {
-		super();
-		this.credentialsId = credentialsId;
-		this.regionName = regionName;
-	}
 
-	AmazonECSClient getAmazonECSClient() {
+    private String credentialsId;
+
+    private String regionName;
+
+    public ECSService(String credentialsId, String regionName) {
+        super();
+        this.credentialsId = credentialsId;
+        this.regionName = regionName;
+    }
+
+    AmazonECSClient getAmazonECSClient() {
         final AmazonECSClient client;
-        
+
         ProxyConfiguration proxy = Jenkins.getInstance().proxy;
-        ClientConfiguration clientConfiguration = new ClientConfiguration();            
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
         if(proxy != null) {
-        	clientConfiguration.setProxyHost(proxy.name);
-        	clientConfiguration.setProxyPort(proxy.port);
-        	clientConfiguration.setProxyUsername(proxy.getUserName());
-        	clientConfiguration.setProxyPassword(proxy.getPassword());
+            clientConfiguration.setProxyHost(proxy.name);
+            clientConfiguration.setProxyPort(proxy.port);
+            clientConfiguration.setProxyUsername(proxy.getUserName());
+            clientConfiguration.setProxyPassword(proxy.getPassword());
         }
-        
+
         AmazonWebServicesCredentials credentials = getCredentials(credentialsId);
         if (credentials == null) {
             // no credentials provided, rely on com.amazonaws.auth.DefaultAWSCredentialsProviderChain
@@ -110,7 +110,7 @@ class ECSService {
         LOGGER.log(Level.FINE, "Selected Region: {0}", regionName);
         return client;
     }
-    
+
     Region getRegion(String regionName) {
         if (StringUtils.isNotEmpty(regionName)) {
             return RegionUtils.getRegion(regionName);
@@ -118,12 +118,12 @@ class ECSService {
             return Region.getRegion(Regions.US_EAST_1);
         }
     }
-    
+
     @CheckForNull
     private AmazonWebServicesCredentials getCredentials(@Nullable String credentialsId) {
         return AWSCredentialsHelper.getCredentials(credentialsId, Jenkins.getActiveInstance());
     }
-    
+
     void deleteTask(String taskArn, String clusterArn) {
         final AmazonECSClient client = getAmazonECSClient();
 
@@ -134,79 +134,79 @@ class ECSService {
             LOGGER.log(Level.SEVERE, "Couldn't stop task arn " + taskArn + " caught exception: " + e.getMessage(), e);
         }
     }
-    
-	String runEcsTask(final ECSSlave slave, final ECSTaskTemplate template, String clusterArn, Collection<String> command) throws IOException, AbortException {
-		AmazonECSClient client = getAmazonECSClient();
-		String definitionArn = template.getTaskDefinitionArn();
-		slave.setTaskDefinitonArn(definitionArn);
 
-		KeyValuePair envNodeName = new KeyValuePair();
-		envNodeName.setName("SLAVE_NODE_NAME");
-		envNodeName.setValue(slave.getComputer().getName());
+    String runEcsTask(final ECSSlave slave, final ECSTaskTemplate template, String clusterArn, Collection<String> command) throws IOException, AbortException {
+        AmazonECSClient client = getAmazonECSClient();
+        String definitionArn = template.getTaskDefinitionArn();
+        slave.setTaskDefinitonArn(definitionArn);
 
-		KeyValuePair envNodeSecret = new KeyValuePair();
-		envNodeSecret.setName("SLAVE_NODE_SECRET");
-		envNodeSecret.setValue(slave.getComputer().getJnlpMac());
+        KeyValuePair envNodeName = new KeyValuePair();
+        envNodeName.setName("SLAVE_NODE_NAME");
+        envNodeName.setValue(slave.getComputer().getName());
 
-		final RunTaskResult runTaskResult = client.runTask(new RunTaskRequest()
-		  .withTaskDefinition(definitionArn)
-		  .withOverrides(new TaskOverride()
-		    .withContainerOverrides(new ContainerOverride()
-		      .withName(template.getFullQualifiedTemplateName(slave.getCloud()))
-		      .withCommand(command)
-		      .withEnvironment(envNodeName)
-		      .withEnvironment(envNodeSecret)))
-		  .withCluster(clusterArn)
-		);
+        KeyValuePair envNodeSecret = new KeyValuePair();
+        envNodeSecret.setName("SLAVE_NODE_SECRET");
+        envNodeSecret.setValue(slave.getComputer().getJnlpMac());
 
-		if (!runTaskResult.getFailures().isEmpty()) {
-		    LOGGER.log(Level.WARNING, "Slave {0} - Failure to run task with definition {1} on ECS cluster {2}", new Object[]{slave.getNodeName(), definitionArn, clusterArn});
-		    for (Failure failure : runTaskResult.getFailures()) {
-		        LOGGER.log(Level.WARNING, "Slave {0} - Failure reason={1}, arn={2}", new Object[]{slave.getNodeName(), failure.getReason(), failure.getArn()});
-		    }			    
-		    throw new AbortException("Failed to run slave container " + slave.getNodeName());
-		}
-		return runTaskResult.getTasks().get(0).getTaskArn();            
-	}
-	
-	void waitForSufficientClusterResources(Date timeout, ECSTaskTemplate template, String clusterArn) throws InterruptedException, AbortException {
-		AmazonECSClient client = getAmazonECSClient();
-		
-		boolean hasEnoughResources = false;			
-		WHILE:
-		do {
-			ListContainerInstancesResult listContainerInstances = client.listContainerInstances(new ListContainerInstancesRequest().withCluster(clusterArn));
-			DescribeContainerInstancesResult containerInstancesDesc = client.describeContainerInstances(new DescribeContainerInstancesRequest().withContainerInstances(listContainerInstances.getContainerInstanceArns()).withCluster(clusterArn));
-			LOGGER.log(Level.INFO, "Found {0} instances", containerInstancesDesc.getContainerInstances().size());
-			for(ContainerInstance instance : containerInstancesDesc.getContainerInstances()) {
-				LOGGER.log(Level.INFO, "Resources found in instance {1}: {0}", new Object[] {instance.getRemainingResources(), instance.getContainerInstanceArn()});
-				Resource memoryResource = null;
-				Resource cpuResource = null;
-				for(Resource resource : instance.getRemainingResources()) {
-					if("MEMORY".equals(resource.getName())) {
-						memoryResource = resource;
-					} else if("CPU".equals(resource.getName())) {
-						cpuResource = resource;
-					}        					
-				}
-				
-				LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemory()});
-				LOGGER.log(Level.INFO, "Instance {0} has {1} units of free cpu. {2} units are required", new Object[]{ instance.getContainerInstanceArn(), cpuResource.getIntegerValue(), template.getCpu()});
-				if(memoryResource.getIntegerValue() >= template.getMemory() 
-						&& cpuResource.getIntegerValue() >= template.getCpu()) {
-					hasEnoughResources = true;
-					break WHILE;
-				}
-			}
-			
-			// sleep 10s and check memory again
-			Thread.sleep(10000);
-		} while(!hasEnoughResources && timeout.after(new Date()));
-		
-		if(!hasEnoughResources) {
-			final String msg = MessageFormat.format("Timeout while waiting for sufficient resources: {0} cpu units, {1}mb free memory", template.getCpu(), template.getMemory());
-		    LOGGER.log(Level.WARNING, msg);
-		    throw new AbortException(msg);
-		}
-	}
+        final RunTaskResult runTaskResult = client.runTask(new RunTaskRequest()
+          .withTaskDefinition(definitionArn)
+          .withOverrides(new TaskOverride()
+            .withContainerOverrides(new ContainerOverride()
+              .withName(template.getFullQualifiedTemplateName(slave.getCloud()))
+              .withCommand(command)
+              .withEnvironment(envNodeName)
+              .withEnvironment(envNodeSecret)))
+          .withCluster(clusterArn)
+        );
+
+        if (!runTaskResult.getFailures().isEmpty()) {
+            LOGGER.log(Level.WARNING, "Slave {0} - Failure to run task with definition {1} on ECS cluster {2}", new Object[]{slave.getNodeName(), definitionArn, clusterArn});
+            for (Failure failure : runTaskResult.getFailures()) {
+                LOGGER.log(Level.WARNING, "Slave {0} - Failure reason={1}, arn={2}", new Object[]{slave.getNodeName(), failure.getReason(), failure.getArn()});
+            }
+            throw new AbortException("Failed to run slave container " + slave.getNodeName());
+        }
+        return runTaskResult.getTasks().get(0).getTaskArn();
+    }
+
+    void waitForSufficientClusterResources(Date timeout, ECSTaskTemplate template, String clusterArn) throws InterruptedException, AbortException {
+        AmazonECSClient client = getAmazonECSClient();
+
+        boolean hasEnoughResources = false;
+        WHILE:
+        do {
+            ListContainerInstancesResult listContainerInstances = client.listContainerInstances(new ListContainerInstancesRequest().withCluster(clusterArn));
+            DescribeContainerInstancesResult containerInstancesDesc = client.describeContainerInstances(new DescribeContainerInstancesRequest().withContainerInstances(listContainerInstances.getContainerInstanceArns()).withCluster(clusterArn));
+            LOGGER.log(Level.INFO, "Found {0} instances", containerInstancesDesc.getContainerInstances().size());
+            for(ContainerInstance instance : containerInstancesDesc.getContainerInstances()) {
+                LOGGER.log(Level.INFO, "Resources found in instance {1}: {0}", new Object[] {instance.getRemainingResources(), instance.getContainerInstanceArn()});
+                Resource memoryResource = null;
+                Resource cpuResource = null;
+                for(Resource resource : instance.getRemainingResources()) {
+                    if("MEMORY".equals(resource.getName())) {
+                        memoryResource = resource;
+                    } else if("CPU".equals(resource.getName())) {
+                        cpuResource = resource;
+                    }
+                }
+
+                LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemory()});
+                LOGGER.log(Level.INFO, "Instance {0} has {1} units of free cpu. {2} units are required", new Object[]{ instance.getContainerInstanceArn(), cpuResource.getIntegerValue(), template.getCpu()});
+                if(memoryResource.getIntegerValue() >= template.getMemory()
+                        && cpuResource.getIntegerValue() >= template.getCpu()) {
+                    hasEnoughResources = true;
+                    break WHILE;
+                }
+            }
+
+            // sleep 10s and check memory again
+            Thread.sleep(10000);
+        } while(!hasEnoughResources && timeout.after(new Date()));
+
+        if(!hasEnoughResources) {
+            final String msg = MessageFormat.format("Timeout while waiting for sufficient resources: {0} cpu units, {1}mb free memory", template.getCpu(), template.getMemory());
+            LOGGER.log(Level.WARNING, msg);
+            throw new AbortException(msg);
+        }
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -42,7 +42,6 @@ import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.ecs.AmazonECSClient;
-import com.amazonaws.services.ecs.model.ClientException;
 import com.amazonaws.services.ecs.model.ContainerInstance;
 import com.amazonaws.services.ecs.model.ContainerOverride;
 import com.amazonaws.services.ecs.model.DescribeContainerInstancesRequest;
@@ -131,7 +130,7 @@ class ECSService {
         LOGGER.log(Level.INFO, "Delete ECS Slave task: {0}", taskArn);
         try {
             client.stopTask(new StopTaskRequest().withTask(taskArn).withCluster(clusterArn));
-        } catch (ClientException e) {
+        } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Couldn't stop task arn " + taskArn + " caught exception: " + e.getMessage(), e);
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
@@ -39,10 +40,15 @@ import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.RetentionStrategy;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ECSSlave extends AbstractCloudSlave {
+
+    private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
 
     @Nonnull
     private final ECSCloud cloud;
@@ -61,8 +67,32 @@ public class ECSSlave extends AbstractCloudSlave {
     @CheckForNull
     private String taskArn;
 
+    private static RetentionStrategy deleteAfterFinished = new RetentionStrategy<ECSComputer>() {
+        @Override
+        public boolean isManualLaunchAllowed(ECSComputer c) {
+            return false;
+        }
+
+        @Override
+        @GuardedBy("hudson.model.Queue.lock")
+        public long check(ECSComputer c) {
+            AbstractCloudSlave node = c.getNode();
+            if(!c.isAcceptingTasks() && node != null) {
+                try {
+                    node.terminate();
+                } catch (InterruptedException e) {
+                    LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
+                }
+            }
+            return 1;
+        }
+
+    };
+
     public ECSSlave(@Nonnull ECSCloud cloud, @Nonnull String name, @Nullable String remoteFS, @Nullable String labelString, @Nonnull ComputerLauncher launcher) throws Descriptor.FormException, IOException {
-        super(name, "ECS slave", remoteFS, 1, Mode.EXCLUSIVE, labelString, launcher, RetentionStrategy.NOOP, Collections.EMPTY_LIST);
+        super(name, "ECS slave", remoteFS, 1, Mode.EXCLUSIVE, labelString, launcher, deleteAfterFinished, Collections.EMPTY_LIST);
         this.cloud = cloud;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -60,7 +60,7 @@ public class ECSSlave extends AbstractCloudSlave {
      */
     @CheckForNull
     private String taskArn;
-    
+
     public ECSSlave(@Nonnull ECSCloud cloud, @Nonnull String name, @Nullable String remoteFS, @Nullable String labelString, @Nonnull ComputerLauncher launcher) throws Descriptor.FormException, IOException {
         super(name, "ECS slave", remoteFS, 1, Mode.EXCLUSIVE, labelString, launcher, RetentionStrategy.NOOP, Collections.EMPTY_LIST);
         this.cloud = cloud;
@@ -102,7 +102,7 @@ public class ECSSlave extends AbstractCloudSlave {
         }
     }
 
-	public ECSCloud getCloud() {
-		return cloud;
-	}
+    public ECSCloud getCloud() {
+        return cloud;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -114,13 +114,13 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     @CheckForNull
     private String entrypoint;
     /**
-      JVM arguments to start slave.jar
+     * JVM arguments to start slave.jar
      */
     @CheckForNull
     private String jvmArgs;
 
     /**
-      Container mount points, imported from volumes
+     * Container mount points, imported from volumes
      */
     private List<MountPointEntry> mountPoints;
 
@@ -480,12 +480,12 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     }
 
     /**
-     * Returns the template name prefixed with the cloud name 
+     * Returns the template name prefixed with the cloud name
      */
     String getFullQualifiedTemplateName(ECSCloud owner) {
-		return owner.getDisplayName().replaceAll("\\s+","") + '-' + templateName;
-	}
-    
+        return owner.getDisplayName().replaceAll("\\s+","") + '-' + templateName;
+    }
+
     public void setOwner(ECSCloud owner) {
         final AmazonECSClient client = owner.getAmazonECSClient();
         if (taskDefinitionArn == null) {
@@ -504,14 +504,14 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     @Extension
     public static class DescriptorImpl extends Descriptor<ECSTaskTemplate> {
-    	
-    	private static String TEMPLATE_NAME_PATTERN = "[a-z|A-Z|0-9|_|-]{1,127}";
+
+        private static String TEMPLATE_NAME_PATTERN = "[a-z|A-Z|0-9|_|-]{1,127}";
 
         @Override
         public String getDisplayName() {
             return Messages.Template();
         }
-        
+
         public FormValidation doCheckTemplateName(@QueryParameter String value) throws IOException, ServletException {
             if (value.length() > 0 && value.length() <= 127 && value.matches(TEMPLATE_NAME_PATTERN)) {
                 return FormValidation.ok();

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -48,6 +48,9 @@
     <f:entry field="jenkinsUrl" title="${%Alternative Jenkins URL}" description="If needed, the Jenkins URL can be overwritten with this property (e.g. to support other HTTP(S) endpoints due to reverse proxies or firewalling). By default the URL from the global Jenkins configuration is used.">
       <f:textbox />
     </f:entry>
+    <f:entry field="slaveTimoutInSeconds" title="${%ECS task creation timeout}" description="Timeout (in second) for ECS task to be created, usefull if you use large docker slave image, because the host will take more time to pull the docker image">
+      <f:textbox />
+    </f:entry>
   </f:advanced>
 
   <f:entry title="${%ECS slave templates}">


### PR DESCRIPTION
AmazonECSClient throw Runtime exception when error, so
https://github.com/jenkinsci/amazon-ecs-plugin/blob/5090b4deedad9c9ec142c44874249884a5a66346/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java#L271
maybe skipped and node will never be deleted

see [runTask](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ecs/AmazonECSClient.html#runTask-com.amazonaws.services.ecs.model.RunTaskRequest-) and [stopTask](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ecs/AmazonECSClient.html#stopTask-com.amazonaws.services.ecs.model.StopTaskRequest-) documentation, they throw [Unchecked exception](https://docs.oracle.com/javase/tutorial/essential/exceptions/runtime.html)