### PR TITLE
JENKINS-40300: Add MemoryReservation to set soft memory limits on the containers

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -190,9 +190,9 @@ class ECSService {
                     }
                 }
 
-                LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemoryReservation()});
+                LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemoryConstraint()});
                 LOGGER.log(Level.INFO, "Instance {0} has {1} units of free cpu. {2} units are required", new Object[]{ instance.getContainerInstanceArn(), cpuResource.getIntegerValue(), template.getCpu()});
-                if(memoryResource.getIntegerValue() >= template.getMemoryReservation()
+                if(memoryResource.getIntegerValue() >= template.getMemoryConstraint()
                         && cpuResource.getIntegerValue() >= template.getCpu()) {
                     hasEnoughResources = true;
                     break WHILE;
@@ -204,7 +204,7 @@ class ECSService {
         } while(!hasEnoughResources && timeout.after(new Date()));
 
         if(!hasEnoughResources) {
-            final String msg = MessageFormat.format("Timeout while waiting for sufficient resources: {0} cpu units, {1}mb free memory", template.getCpu(), template.getMemoryReservation());
+            final String msg = MessageFormat.format("Timeout while waiting for sufficient resources: {0} cpu units, {1}mb free memory", template.getCpu(), template.getMemoryConstraint());
             LOGGER.log(Level.WARNING, msg);
             throw new AbortException(msg);
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -190,9 +190,9 @@ class ECSService {
                     }
                 }
 
-                LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemory()});
+                LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemoryReservation()});
                 LOGGER.log(Level.INFO, "Instance {0} has {1} units of free cpu. {2} units are required", new Object[]{ instance.getContainerInstanceArn(), cpuResource.getIntegerValue(), template.getCpu()});
-                if(memoryResource.getIntegerValue() >= template.getMemory()
+                if(memoryResource.getIntegerValue() >= template.getMemoryReservation()
                         && cpuResource.getIntegerValue() >= template.getCpu()) {
                     hasEnoughResources = true;
                     break WHILE;
@@ -204,7 +204,7 @@ class ECSService {
         } while(!hasEnoughResources && timeout.after(new Date()));
 
         if(!hasEnoughResources) {
-            final String msg = MessageFormat.format("Timeout while waiting for sufficient resources: {0} cpu units, {1}mb free memory", template.getCpu(), template.getMemory());
+            final String msg = MessageFormat.format("Timeout while waiting for sufficient resources: {0} cpu units, {1}mb free memory", template.getCpu(), template.getMemoryReservation());
             LOGGER.log(Level.WARNING, msg);
             throw new AbortException(msg);
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -106,6 +106,15 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      * @see ContainerDefinition#withMemoryReservation(Integer)
      */
     private final int memoryReservation;
+
+    /* a hint to ECSService regarding whether it can ask AWS to make a new container or not */
+    public int getMemoryConstraint() {
+        if (this.memoryReservation > 0) {
+            return this.memoryReservation;
+        }
+        return this.memory;
+    }
+
     /**
      * The number of <code>cpu</code> units reserved for the container. A
      * container instance has 1,024 <code>cpu</code> units for every CPU

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -91,16 +91,17 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      * The number of MiB of memory reserved for the Docker container. If your
      * container attempts to exceed the memory allocated here, the container
      * is killed by ECS.
-     * Also referred to as the hard memory limit
      *
      * @see ContainerDefinition#withMemory(Integer)
      */
     private final int memory;
     /**
-     * The number of MiB of memory reserved for the Docker container. If your
-     * container attempts to exceed the memory allocated here, the container
-     * is killed by ECS.
-     * Also referred to as the soft memory limit
+     * The soft limit (in MiB) of memory to reserve for the container. When
+     * system memory is under contention, Docker attempts to keep the container
+     * memory to this soft limit; however, your container can consume more
+     * memory when it needs to, up to either the hard limit specified with the
+     * memory parameter (if applicable), or all of the available memory on the
+     * container instance, whichever comes first.
      *
      * @see ContainerDefinition#withMemoryReservation(Integer)
      */

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -91,10 +91,20 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      * The number of MiB of memory reserved for the Docker container. If your
      * container attempts to exceed the memory allocated here, the container
      * is killed by ECS.
+     * Also referred to as the hard memory limit
      *
      * @see ContainerDefinition#withMemory(Integer)
      */
     private final int memory;
+    /**
+     * The number of MiB of memory reserved for the Docker container. If your
+     * container attempts to exceed the memory allocated here, the container
+     * is killed by ECS.
+     * Also referred to as the soft memory limit
+     *
+     * @see ContainerDefinition#withMemoryReservation(Integer)
+     */
+    private final int memoryReservation;
     /**
      * The number of <code>cpu</code> units reserved for the container. A
      * container instance has 1,024 <code>cpu</code> units for every CPU
@@ -160,6 +170,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
                            @Nonnull String image,
                            @Nullable String remoteFSRoot,
                            int memory,
+                           int memoryReservation,
                            int cpu,
                            boolean privileged,
                            @Nullable List<LogDriverOption> logDriverOptions,
@@ -174,6 +185,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         this.image = image;
         this.remoteFSRoot = remoteFSRoot;
         this.memory = memory;
+        this.memoryReservation = memoryReservation;
         this.cpu = cpu;
         this.privileged = privileged;
         this.logDriverOptions = logDriverOptions;
@@ -211,6 +223,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     public int getMemory() {
         return memory;
+    }
+
+    public int getMemoryReservation() {
+        return memoryReservation;
     }
 
     public int getCpu() {
@@ -454,10 +470,14 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
                 .withImage(image)
                 .withEnvironment(getEnvironmentKeyValuePairs())
                 .withExtraHosts(getExtraHostEntries())
-                .withMemory(memory)
+                .withMemoryReservation(memoryReservation)
                 .withMountPoints(getMountPointEntries())
                 .withCpu(cpu)
                 .withPrivileged(privileged);
+
+        if (memory > 0) /* this is the hard limit */
+            def.withMemory(memory);
+
         if (entrypoint != null)
             def.withEntryPoint(StringUtils.split(entrypoint));
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -529,16 +529,6 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     private static final Logger LOGGER = Logger.getLogger(ECSTaskTemplate.class.getName());
 
-    public class MemoryValidationError extends Exception {
-        String e;
-        MemoryValidationError(String e) {
-            this.e = e;
-        }
-        public String toString() {
-            return this.e;
-        }
-    }
-
     @Extension
     public static class DescriptorImpl extends Descriptor<ECSTaskTemplate> {
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -37,8 +37,11 @@
   <f:entry title="${%Filesystem root}" field="remoteFSRoot">
     <f:textbox default="/home/jenkins" />
   </f:entry>
+  <f:entry title="${%Memory Reservation (Mb)}" field="memoryReservation">
+    <f:textbox default="1"/>
+  </f:entry>
   <f:entry title="${%Memory (Mb)}" field="memory">
-    <f:textbox />
+    <f:textbox default="0"/>
   </f:entry>
   <f:entry title="${%CPU units}" field="cpu">
     <f:textbox default="1"/>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -37,10 +37,10 @@
   <f:entry title="${%Filesystem root}" field="remoteFSRoot">
     <f:textbox default="/home/jenkins" />
   </f:entry>
-  <f:entry title="${%Memory Reservation (Mb)}" field="memoryReservation">
+  <f:entry title="${%Soft Memory Reservation (Mb)}" field="memoryReservation" description="The soft memory limit in Mb for the container. A 0 value implies no limit will be assigned. If in doubt apply a limit here and leave the Hard Memory Reservation to 0.">
     <f:textbox default="0"/>
   </f:entry>
-  <f:entry title="${%Memory (Mb)}" field="memory">
+  <f:entry title="${%Hard Memory Reservation (Mb)}" field="memory" description="The hard memory limit in Mb for the container. A 0 value implies no limit will be assigned">
     <f:textbox default="0"/>
   </f:entry>
   <f:entry title="${%CPU units}" field="cpu">

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -38,7 +38,7 @@
     <f:textbox default="/home/jenkins" />
   </f:entry>
   <f:entry title="${%Memory Reservation (Mb)}" field="memoryReservation">
-    <f:textbox default="1"/>
+    <f:textbox default="0"/>
   </f:entry>
   <f:entry title="${%Memory (Mb)}" field="memory">
     <f:textbox default="0"/>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-memory.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-memory.html
@@ -22,4 +22,4 @@
   ~  THE SOFTWARE.
   ~
   -->
-The hard limit (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed.
+The hard limit (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed. Either one of memory or memoryReservation must be set with 0 being "don't apply a limit"

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-memoryReservation.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-memoryReservation.html
@@ -22,4 +22,4 @@
   ~  THE SOFTWARE.
   ~
   -->
-The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first.
+The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first. Either one of memory or memoryReservation must be set with 0 being "don't apply a limit"

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-memoryReservation.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-memoryReservation.html
@@ -22,4 +22,4 @@
   ~  THE SOFTWARE.
   ~
   -->
-The hard limit (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed.
+The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first.


### PR DESCRIPTION
Provide support for setting of the soft memory (memoryReservation) and or the hard memory (memory) settings when creating the task container.

Even though the documentation for the API specifies that it's possible to not set either of these, AWS prevents creation of task templates which do not have one of either memory or memoryReservation set.

By adding the soft memory setting it means that you can have a container spawn & use more than the memory reservation.

In my context setting the hard limit was leading to the kernel oom-killer process often killing the Jenkins Slave Agent JVM & I'd much prefer this not to happen.

The soft limit is a cue to the scheduler to not overcommit memory, so it's fair enough that's it's there 