### PR TITLE
Allow Specification of Task Role ARN for ECS Slave Templates

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -113,21 +113,22 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      */
     @CheckForNull
     private String entrypoint;
-  
+
     /**
      * ARN of the IAM role to use for the slave ECS task
+     *
+     * @see RegisterTaskDefinitionRequest#withTaskRoleArn(String)
      */
     @CheckForNull
-    private String taskRoleArn;
-  
+    private String taskrole;
     /**
-     * JVM arguments to start slave.jar
+      JVM arguments to start slave.jar
      */
     @CheckForNull
     private String jvmArgs;
 
     /**
-     * Container mount points, imported from volumes
+      Container mount points, imported from volumes
      */
     private List<MountPointEntry> mountPoints;
 
@@ -190,8 +191,8 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     }
 
     @DataBoundSetter
-    public void setTaskRoleArn(String taskRoleArn) {
-        this.taskRoleArn = StringUtils.trimToNull(taskRoleArn);
+    public void setTaskrole(String taskRoleArn) {
+        this.taskrole = StringUtils.trimToNull(taskRoleArn);
     }
 
     @DataBoundSetter
@@ -233,8 +234,8 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         return entrypoint;
     }
 
-    public String getTaskRoleArn() {
-        return taskRoleArn;
+    public String getTaskrole() {
+        return taskrole;
     }
 
     public String getJvmArgs() {
@@ -489,11 +490,16 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
             def.withLogConfiguration(logConfig);
         }
 
-        return new RegisterTaskDefinitionRequest()
-            .withFamily(familyName)
-            .withVolumes(getVolumeEntries())
-            .withContainerDefinitions(def)
-            .withTaskRoleArn(taskRoleArn);
+        final RegisterTaskDefinitionRequest request = new RegisterTaskDefinitionRequest()
+                .withFamily(familyName)
+                .withVolumes(getVolumeEntries())
+                .withContainerDefinitions(def);
+
+        if (taskrole != null) {
+            request.withTaskRoleArn(taskrole);
+        }
+
+        return request;
     }
 
     /**

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -44,7 +44,7 @@
     <f:textbox default="1"/>
   </f:entry>
   <f:advanced>
-    <f:entry title="${%ECS Task Role ARN}" field="taskRoleArn">
+    <f:entry title="${%Task Role ARN}" field="taskrole">
       <f:textbox />
     </f:entry>
     <f:entry title="${%Override entrypoint}" field="entrypoint">

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-taskrole.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-taskrole.html
@@ -1,0 +1,41 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+<p>
+    AWS IAM Role to associate with the ECS Slave Task to grant permissions to access other AWS resources.
+</p>
+<p>
+    If your slave needs access to other AWS resources, you can create a role with appropriate policies and associate
+    that role with the slave ECS Task.
+</p>
+<p>
+    All containers within a task have access to all permissions defined in the instance profile of the container instances.
+    It is recommended to limit the permissions of container instances and specify service specific permissions at the
+    task level.
+</p>
+<p>
+    See <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html">Task IAM roles</a> for
+    more details about task roles.
+</p>


### PR DESCRIPTION
Sorry for creating a second pull request for the same feature. It seems like the other PR is not moving.

- I've used the changes by `joh-m`
- Updated the logic to check if task role is specified and only then, add it to the register task def request
- Added a helpfile for the taskRoleArn field

**A few notes**:

I've packaged this plugin and tested it on a Jenkins master running on Amazon ECS. 
There is a gotcha with regards to passing a role ARN to a task:
- The role assumed by the jenkins master (task or ec2-instance) needs to have an `iam:PassRole` policy for any roles which you wish to assign to a slave task

Otherwise you'll get an error similar to the following:

`User: A is not authorized to perform: iam:PassRole on resource: B`
Where A is the arn of the role assumed by the jenkins Master and B is the arn of the role you are trying to specify via taskRoleArn

An example policy statement for the Jenkins Master Task to have permission to assign task roles would look like:

```json
{
            "Effect": "Allow",
            "Action": "iam:PassRole",
            "Resource": "arn:aws:iam::444913385113:role/*"
}
```

- I changed the name of the field from `taskRoleArn` to `taskrole`. For some reason, when  i used the camel case field name, the corresponding help file was not being picked up. I tried including the case in the helpfile name and remove case but nothing seemed to work. Perhaps someone more experienced with the nuances of Jelly help file resolution could shed some light 