### PR TITLE
Fix task definitions registory (add DNS search option)

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -174,6 +174,9 @@ class ECSService {
         if (template.getMemory() > 0) /* this is the hard limit */
             def.withMemory(template.getMemory());
 
+        if (template.getDnsSearchDomains() != null)
+            def.withDnsSearchDomains(StringUtils.split(template.getDnsSearchDomains()));
+
         if (template.getEntrypoint() != null)
             def.withEntryPoint(StringUtils.split(template.getEntrypoint()));
 


### PR DESCRIPTION
- I found bugs that DNS search domains cannot be registered with task definition.
- I had made a mistake in resolving conflict on this commit and it was merged (sorry....): https://github.com/jenkinsci/amazon-ecs-plugin/commit/7039fc91c6984279870f29728657fa10a1071e98#diff-b6ed2a1d9bd787de97cfb63106ab68f3L540
