### PR TITLE
Support for existing TaskDefinitions in AWS

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -250,7 +250,7 @@ public class ECSCloud extends Cloud {
                 getEcsService().waitForSufficientClusterResources(timeout, task, cluster);
 
                 String uniq = Long.toHexString(System.nanoTime());
-                slave = new ECSSlave(ECSCloud.this, name + "-" + uniq, task.getRemoteFSRoot(),
+                slave = new ECSSlave(ECSCloud.this, name + "-" + task.getLabel() + "-" + uniq, task.getRemoteFSRoot(),
                         label == null ? null : label.toString(), new JNLPLauncher());
                 slave.setClusterArn(cluster);
                 Jenkins.getInstance().addNode(slave);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTask.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTask.java
@@ -1,0 +1,14 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+public interface ECSTask {
+
+    int getMemoryConstraint();
+
+    int getCpu();
+
+    String getRemoteFSRoot();
+
+    String getDisplayName();
+
+    String getLabel();
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition.java
@@ -1,0 +1,155 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import com.amazonaws.services.ecs.model.ContainerDefinition;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Label;
+import hudson.model.labels.LabelAtom;
+import hudson.util.FormValidation;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.Set;
+
+public class ECSTaskDefinition extends AbstractDescribableImpl<ECSTaskDefinition> implements ECSTask {
+
+    /**
+     * Task definition
+     */
+    @Nonnull
+    private final String taskDefinitionName;
+
+    @Nonnull
+    private final String jenkinsContainerName;
+    /**
+     * White-space separated list of {@link hudson.model.Node} labels.
+     *
+     * @see Label
+     */
+    @CheckForNull
+    private final String label;
+
+    @DataBoundConstructor
+    public ECSTaskDefinition(@Nonnull String taskDefinitionName,
+                             @Nonnull String jenkinsContainerName, @Nullable String label, int memory,
+                             int memoryReservation,
+                             int cpu, @Nullable String remoteFSRoot) {
+        this.taskDefinitionName = taskDefinitionName;
+        this.jenkinsContainerName = jenkinsContainerName;
+        this.label = label;
+        this.memory = memory;
+        this.memoryReservation = memoryReservation;
+        this.cpu = cpu;
+        this.remoteFSRoot = remoteFSRoot;
+    }
+
+    /**
+     * The number of MiB of memory reserved for the Docker container. If your
+     * container attempts to exceed the memory allocated here, the container
+     * is killed by ECS.
+     *
+     * @see ContainerDefinition#withMemory(Integer)
+     */
+    private final int memory;
+    /**
+     * The soft limit (in MiB) of memory to reserve for the container. When
+     * system memory is under contention, Docker attempts to keep the container
+     * memory to this soft limit; however, your container can consume more
+     * memory when it needs to, up to either the hard limit specified with the
+     * memory parameter (if applicable), or all of the available memory on the
+     * container instance, whichever comes first.
+     *
+     * @see ContainerDefinition#withMemoryReservation(Integer)
+     */
+    private final int memoryReservation;
+
+    /* a hint to ECSService regarding whether it can ask AWS to make a new container or not */
+    public int getMemoryConstraint() {
+        if (this.memoryReservation > 0) {
+            return this.memoryReservation;
+        }
+        return this.memory;
+    }
+
+    /**
+     * The number of <code>cpu</code> units reserved for the container. A
+     * container instance has 1,024 <code>cpu</code> units for every CPU
+     * core. This parameter specifies the minimum amount of CPU to reserve
+     * for a container, and containers share unallocated CPU units with other
+     * containers on the instance with the same ratio as their allocated
+     * amount.
+     *
+     * @see ContainerDefinition#withCpu(Integer)
+     */
+    private final int cpu;
+
+    /**
+     * Slave remote FS
+     */
+    @Nullable
+    private final String remoteFSRoot;
+
+
+    public int getMemory() {
+        return memory;
+    }
+
+    public int getMemoryReservation() {
+        return memoryReservation;
+    }
+
+    public int getCpu() {
+        return cpu;
+    }
+
+
+    public String getLabel() {
+        return label;
+    }
+
+    public Set<LabelAtom> getLabelSet() {
+        return Label.parse(label);
+    }
+
+    public String getDisplayName() {
+        return "ECS Slave " + label;
+    }
+
+    public String getRemoteFSRoot() {
+        return remoteFSRoot;
+    }
+
+    @Nonnull
+    public String getTaskDefinitionName() {
+        return taskDefinitionName;
+    }
+
+    @Nonnull
+    public String getJenkinsContainerName() {
+        return jenkinsContainerName;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ECSTaskDefinition> {
+
+        private static String TASK_DEFINITION_NAME_PATTERN = "[a-z|A-Z|0-9|_|-]{1,127}";
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Template();
+        }
+
+        public FormValidation doCheckTaskDefinitionName(@QueryParameter String value) throws IOException, ServletException {
+            if (value.length() > 0 && value.length() <= 127 && value.matches(TASK_DEFINITION_NAME_PATTERN)) {
+                return FormValidation.ok();
+            }
+            return FormValidation.error("Up to 127 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed");
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -25,20 +25,13 @@
 
 package com.cloudbees.jenkins.plugins.amazonecs;
 
-import com.amazonaws.services.ecs.model.ContainerDefinition;
-import com.amazonaws.services.ecs.model.HostEntry;
-import com.amazonaws.services.ecs.model.Volume;
-import com.amazonaws.services.ecs.model.HostVolumeProperties;
-import com.amazonaws.services.ecs.model.MountPoint;
-import com.amazonaws.services.ecs.model.KeyValuePair;
-import com.amazonaws.services.ecs.model.RegisterTaskDefinitionRequest;
+import com.amazonaws.services.ecs.model.*;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Label;
 import hudson.model.labels.LabelAtom;
 import hudson.util.FormValidation;
-
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -48,14 +41,13 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.servlet.ServletException;
-
 import java.io.IOException;
 import java.util.*;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
+public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> implements ECSTask {
 
     /**
      * Template Name
@@ -71,6 +63,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     private final String label;
     /**
      * Docker image
+     *
      * @see ContainerDefinition#withImage(String)
      */
     @Nonnull
@@ -144,13 +137,13 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     @CheckForNull
     private String taskrole;
     /**
-      JVM arguments to start slave.jar
+     * JVM arguments to start slave.jar
      */
     @CheckForNull
     private String jvmArgs;
 
     /**
-      Container mount points, imported from volumes
+     * Container mount points, imported from volumes
      */
     private List<MountPointEntry> mountPoints;
 
@@ -163,21 +156,21 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     private List<ExtraHostEntry> extraHosts;
 
     /**
-    * The log configuration specification for the container.
-    * This parameter maps to LogConfig in the Create a container section of
-    * the Docker Remote API and the --log-driver option to docker run.
-    * Valid log drivers are displayed in the LogConfiguration data type.
-    * This parameter requires version 1.18 of the Docker Remote API or greater
-    * on your container instance. To check the Docker Remote API version on
-    * your container instance, log into your container instance and run the
-    * following command: sudo docker version | grep "Server API version"
-    * The Amazon ECS container agent running on a container instance must
-    * register the logging drivers available on that instance with the
-    * ECS_AVAILABLE_LOGGING_DRIVERS environment variable before containers
-    * placed on that instance can use these log configuration options.
-    * For more information, see Amazon ECS Container Agent Configuration
-    * in the Amazon EC2 Container Service Developer Guide.
-    */
+     * The log configuration specification for the container.
+     * This parameter maps to LogConfig in the Create a container section of
+     * the Docker Remote API and the --log-driver option to docker run.
+     * Valid log drivers are displayed in the LogConfiguration data type.
+     * This parameter requires version 1.18 of the Docker Remote API or greater
+     * on your container instance. To check the Docker Remote API version on
+     * your container instance, log into your container instance and run the
+     * following command: sudo docker version | grep "Server API version"
+     * The Amazon ECS container agent running on a container instance must
+     * register the logging drivers available on that instance with the
+     * ECS_AVAILABLE_LOGGING_DRIVERS environment variable before containers
+     * placed on that instance can use these log configuration options.
+     * For more information, see Amazon ECS Container Agent Configuration
+     * in the Amazon EC2 Container Service Developer Guide.
+     */
     @CheckForNull
     private String logDriver;
     private List<LogDriverOption> logDriverOptions;
@@ -285,9 +278,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         return logDriver;
     }
 
-    public String getTemplateName() {return templateName; }
+    public String getTemplateName() {
+        return templateName;
+    }
 
-    public static class LogDriverOption extends AbstractDescribableImpl<LogDriverOption>{
+    public static class LogDriverOption extends AbstractDescribableImpl<LogDriverOption> {
         public String name, value;
 
         @DataBoundConstructor
@@ -314,11 +309,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         return logDriverOptions;
     }
 
-    Map<String,String> getLogDriverOptionsMap() {
+    Map<String, String> getLogDriverOptionsMap() {
         if (null == logDriverOptions || logDriverOptions.isEmpty()) {
             return null;
         }
-        Map<String,String> options = new HashMap<String,String>();
+        Map<String, String> options = new HashMap<String, String>();
         for (LogDriverOption logDriverOption : logDriverOptions) {
             String name = logDriverOption.name;
             String value = logDriverOption.value;
@@ -376,17 +371,17 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     Collection<Volume> getVolumeEntries() {
         Collection<Volume> vols = new LinkedList<Volume>();
-        if (null != mountPoints ) {
+        if (null != mountPoints) {
             for (MountPointEntry mount : mountPoints) {
                 String name = mount.name;
                 String sourcePath = mount.sourcePath;
                 HostVolumeProperties hostVolume = new HostVolumeProperties();
                 if (StringUtils.isEmpty(name))
                     continue;
-                if (! StringUtils.isEmpty(sourcePath))
+                if (!StringUtils.isEmpty(sourcePath))
                     hostVolume.setSourcePath(sourcePath);
                 vols.add(new Volume().withName(name)
-                                     .withHost(hostVolume));
+                        .withHost(hostVolume));
             }
         }
         return vols;
@@ -403,8 +398,8 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
             if (StringUtils.isEmpty(src) || StringUtils.isEmpty(path))
                 continue;
             mounts.add(new MountPoint().withSourceVolume(src)
-                                       .withContainerPath(path)
-                                       .withReadOnly(ro));
+                    .withContainerPath(path)
+                    .withReadOnly(ro));
         }
         return mounts;
     }
@@ -473,9 +468,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         @Override
         public String toString() {
             return "MountPointEntry{name:" + name +
-                   ", sourcePath:" + sourcePath +
-                   ", containerPath:" + containerPath +
-                   ", readOnly:" + readOnly + "}";
+                    ", sourcePath:" + sourcePath +
+                    ", containerPath:" + containerPath +
+                    ", readOnly:" + readOnly + "}";
         }
 
         @Extension
@@ -514,11 +509,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
         /* we validate both memory and memoryReservation fields to the same rules */
         public FormValidation doCheckMemory(@QueryParameter("memory") int memory, @QueryParameter("memoryReservation") int memoryReservation) throws IOException, ServletException {
-            return validateMemorySettings(memory,memoryReservation);
+            return validateMemorySettings(memory, memoryReservation);
         }
 
         public FormValidation doCheckMemoryReservation(@QueryParameter("memory") int memory, @QueryParameter("memoryReservation") int memoryReservation) throws IOException, ServletException {
-            return validateMemorySettings(memory,memoryReservation);
+            return validateMemorySettings(memory, memoryReservation);
         }
 
         private FormValidation validateMemorySettings(int memory, int memoryReservation) {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -24,7 +24,7 @@
   ~
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry field="name" title="${%Name}" >
     <f:textbox />
   </f:entry>
@@ -62,4 +62,15 @@
       </f:entry>
     </f:repeatableProperty>
   </f:entry>
+
+  <f:entry title="${%ECS task definitions}">
+    <f:repeatableProperty field="taskDefinitions">
+      <f:entry title="">
+        <div align="right">
+          <f:repeatableDeleteButton/>
+        </div>
+      </f:entry>
+    </f:repeatableProperty>
+  </f:entry>
+
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition/config.jelly
@@ -1,0 +1,27 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="Label" field="label">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Task Definition Name}" field="taskDefinitionName" description="Task Definition Name">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Soft Memory Reservation (Mb)}" field="memoryReservation"
+             description="The soft memory limit in Mb for the container. A 0 value implies no limit will be assigned. If in doubt apply a limit here and leave the Hard Memory Reservation to 0.">
+        <f:textbox default="0"/>
+    </f:entry>
+    <f:entry title="${%Hard Memory Reservation (Mb)}" field="memory"
+             description="The hard memory limit in Mb for the container. A 0 value implies no limit will be assigned">
+        <f:textbox default="0"/>
+    </f:entry>
+    <f:entry title="${%CPU units}" field="cpu">
+        <f:textbox default="1"/>
+    </f:entry>
+    <f:entry title="${%Filesystem root}" field="remoteFSRoot">
+        <f:textbox default="/home/jenkins"/>
+    </f:entry>
+    <f:entry title="${%Task Definition Jenkins Container Name}" field="jenkinsContainerName"
+             description="Task Definition Jenkins Container Name">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition/help-memory.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition/help-memory.html
@@ -1,0 +1,25 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+The hard limit (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed. Either one of memory or memoryReservation must be set with 0 being "don't apply a limit"

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition/help-memoryReservation.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition/help-memoryReservation.html
@@ -1,0 +1,25 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first. Either one of memory or memoryReservation must be set with 0 being "don't apply a limit"

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition/help-taskDefinitionName.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskDefinition/help-taskDefinitionName.html
@@ -1,0 +1,25 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+The name of the task definition in AWS. This will be used as task definition in ECS to run.


### PR DESCRIPTION
Support custom TaskDefinitions that could contain multiple docker containers (need to have jenkins-node container included).

This commit adds new type of Task : "Task Definition" to be added on settings page.

Doesn't break any existing functionality.