### PR TITLE
Allow multiple slaves to run with the same template

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -189,11 +189,13 @@ public class ECSCloud extends Cloud {
     @Override
     public Collection<NodeProvisioner.PlannedNode> provision(Label label, int excessWorkload) {
         try {
+			LOGGER.log(Level.INFO, "Asked to provision {0} slave(s) for: {1}", new Object[]{excessWorkload, label});
 
             List<NodeProvisioner.PlannedNode> r = new ArrayList<NodeProvisioner.PlannedNode>();
             final ECSTaskTemplate template = getTemplate(label);
 
             for (int i = 1; i <= excessWorkload; i++) {
+				LOGGER.log(Level.INFO, "Will provision {0}, for label: {1}", new Object[]{template.getDisplayName(), label} );
 
                 r.add(new NodeProvisioner.PlannedNode(template.getDisplayName(), Computer.threadPoolForRemoting
                   .submit(new ProvisioningCallback(template, label)), 1));

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputer.java
@@ -28,29 +28,52 @@ package com.cloudbees.jenkins.plugins.amazonecs;
 import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Amazon EC2 Container Service implementation of {@link hudson.model.Computer}
  *
+ * This Computer should only handle a single task and then be shutdown.
+ *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ECSComputer extends AbstractCloudComputer {
+    private static final Logger LOGGER = Logger.getLogger(ECSComputer.class.getName());
 
     public ECSComputer(ECSSlave slave) {
         super(slave);
     }
 
     @Override
+    public void taskAccepted(Executor executor, Queue.Task task) {
+        super.taskAccepted(executor, task);
+
+        LOGGER.log(Level.FINE, "Computer {0} taskAccepted", this);
+        
+        // Now that we have a task, we want to make sure to tell Jenkins
+        // that this computer is no longer accepting any additional tasks.
+        setAcceptingTasks(false);
+    }
+
+    @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
         super.taskCompleted(executor, task, durationMS);
+        
+        LOGGER.log(Level.FINE, "Computer {0} taskCompleted", this);
+        
         terminate();
     }
 
     @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
         super.taskCompletedWithProblems(executor, task, durationMS, problems);
+        
+        LOGGER.log(Level.FINE, "Computer {0} taskCompletedWithProblems", this);
+        
         terminate();
     }
 
@@ -58,7 +81,22 @@ public class ECSComputer extends AbstractCloudComputer {
      * Computer is terminated after build completion so we enforce it will only be used once.
      */
     private void terminate() {
-        setAcceptingTasks(false);
+        LOGGER.log(Level.INFO, "Attempting to terminate the node for computer: {0}", this);
+        
+        // The task has been completed, so we want to make sure to tell Jenkins
+        // that this computer is no longer accepting tasks.
+        AbstractCloudSlave node = getNode();
+        if( node != null ) {
+            LOGGER.log(Level.INFO, "Terminating the node for computer: {0}", this);
+            try {
+                node.terminate();
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.WARNING, "Failed to terminate computer: " + getName(), e);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to terminate computer: " + getName(), e);
+            }
+        } else {
+            LOGGER.log(Level.WARNING, "There is no node for computer: {0}", this);
+        }
     }
-
 }


### PR DESCRIPTION
Previously, Jenkins would only run one task per template.  This meant that even though ECS could be used to spin up a dozen containers to run a dozen parallel jobs, if they used the same template, then they would all pile up and run one at a time.

I got around this by having the Computer instances tell Jenkins that they were not accepting any new tasks once they had started working on a task. This way, Jenkins would see a busy ECS slave node as completely done and spin up a new one.

The logging in ECSCloud.java is for parity with `docker-plugin`.