### PR TITLE
Allow using externally-managed task definitions

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -71,6 +71,13 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      */
     @CheckForNull
     private final String label;
+
+    /**
+     * Task Definition Override to use, instead of a Jenkins-managed Task definition. May be a family name or an ARN.
+     */
+    @CheckForNull
+    private final String taskDefinitionOverride;
+
     /**
      * Docker image
      * @see ContainerDefinition#withImage(String)
@@ -194,6 +201,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     @DataBoundConstructor
     public ECSTaskTemplate(@Nonnull String templateName,
                            @Nullable String label,
+                           @Nullable String taskDefinitionOverride,
                            @Nonnull String image,
                            @Nullable String remoteFSRoot,
                            int memory,
@@ -206,10 +214,20 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
                            @Nullable List<ExtraHostEntry> extraHosts,
                            @Nullable List<MountPointEntry> mountPoints,
                            @Nullable List<PortMappingEntry> portMappings) {
-        // If the template name is empty we will add a default name and a
-        // random element that will help to find it later when we want to delete it.
-        this.templateName = templateName.isEmpty() ?
-                "jenkinsTask-" + UUID.randomUUID().toString() : templateName;
+        // if the user enters a task definition override, always prefer to use it, rather than the jenkins template.
+        if (taskDefinitionOverride != null && !taskDefinitionOverride.trim().isEmpty()) {
+            this.taskDefinitionOverride = taskDefinitionOverride.trim();
+            // Always set the template name to the empty string if we are using a task definition override,
+            // since we don't want Jenkins to touch our definitions.
+            this.templateName = "";
+        } else {
+            // If the template name is empty we will add a default name and a
+            // random element that will help to find it later when we want to delete it.
+            this.templateName = templateName.isEmpty() ?
+                    "jenkinsTask-" + UUID.randomUUID().toString() : templateName;
+            // Make sure we don't have both a template name and a task definition override.
+            this.taskDefinitionOverride = null;
+        }
         this.label = label;
         this.image = image;
         this.remoteFSRoot = remoteFSRoot;
@@ -257,6 +275,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     public String getLabel() {
         return label;
+    }
+
+    public String getTaskDefinitionOverride() {
+        return taskDefinitionOverride;
     }
 
     public String getImage() {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -25,11 +25,14 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%Template Name}" field="templateName">
+  <f:entry title="Label" field="label" description="The label used to identify this slave in Jenkins.">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="${%Template Name}" field="templateName" description="The name that will be appended to the ECS cluster name when creating task definitions. Cannot be used with a Task Definition Override.">
       <f:textbox />
     </f:entry>
-  <f:entry title="Label" field="label">
-    <f:textbox />
+  <f:entry title="${%Task Definition Override}" field="taskDefinitionOverride" description="Externally-managed ECS task definition to use, instead of creating task definitions using the Template Name. This value takes precedence over all other container settings.">
+      <f:textbox />
   </f:entry>
   <f:entry title="${%Docker Image}" field="image">
     <f:textbox default="jenkinsci/jnlp-slave" />

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-externalTaskDefinition.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-externalTaskDefinition.html
@@ -1,0 +1,48 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+<p>
+    Use an externally-managed task definition, rather than one created by Jenkins. Allows you to use a task definition
+    created in the AWS Console, command line, or other tools. Specifying an explicit task definition will override all
+    other task definition options, and will prevent Jenkins from creating or modifying task definitions for this slave.
+    (You should still specify reasonable CPU and memory sizes in Jenkins. The values will not be used by ECS, but will be
+    used by Jenkins to estimate cluster capacity.)
+</p>
+<p>
+    You may specify either a full task definition ARN, a family name, or a family name and revision. If specifying only a
+    family name, Jenkins will use the latest active task definition with that family name. If you enter the full ARN, Jenkins will
+    always use the specified ARN, even if you create later revisions of the task definition. See the
+    <a href="http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTaskDefinition.html">DescribeTaskDefinition API documentation</a>
+    for details.
+</p>
+<p>
+    For example, if the task definition you would like to use is in the "hello_world" family, you could enter
+    "hello_world", "hello_world:8", or "arn:aws:ecs:us-east-1:123456789012:task-definition/hello_world:8" as the Task
+    Definition Override.
+</p>
+<p>
+    <b>Important:</b> If your externally-managed task definition contains multiple container definitions (sidecars), the
+    Jenkins slave container must be the first container defined in the task definition.
+</p>
+


### PR DESCRIPTION
This PR is similar in spirit to PR #45, but is more flexible. In essence, it allows you to set a "Task Definition Override" that will instruct the ECS plugin to look for the task definition in ECS, and will prevent the plugin from creating or updating task definitions.

The motivation for this PR is the lack of options in the ECS plugin's task definition screen. For example, we can't add sidecar containers through the Jenkins UI. Rather than trying to duplicate the UI of the AWS Console in Jenkins, we can just allow users to manage their task definitions through the AWS Console itself, or through any other mechanism. (I'm using terraform to manage the task definitions, which is working very well.)

The changes here are actually quite straightforward:

- Provide a "Task Definition Override" that can be a task definition family (e.g. jenkins-slave), family and revision (jenkins-slave:9), or full task definition ARN.
- Prefer the Task Definition Override to the Template Name, if the Override is present. Do not attempt to update the Task Definition based on any other configuration in the ECS Plugin (cpu, memory, volumes, etc.).
- If there is more than one container in the task definition, always assume the jenkins slave is the first container listed (for command line and environment variable overrides)

The CPU and Memory settings in the UI are actually used when the Task Definition Override is set, but only for the ECS Plugin's own capacity checks. They are never persisted to ECS. It would be quite possible to first find the Task Definition in AWS and calculate the memory and CPU, but that seems like a worthy follow-on effort.