### PR TITLE
Add support for specifying Task Execution Role ARN

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>aws-java-sdk</artifactId>
-			<version>1.11.37</version>
+			<version>1.11.264</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -203,16 +203,17 @@ class ECSService {
         boolean templateMatchesExistingContainerDefinition = false;
         boolean templateMatchesExistingVolumes = false;
         boolean templateMatchesExistingTaskRole = false;
+        boolean templateMatchesExistingExecutionRole = false;
 
         DescribeTaskDefinitionResult describeTaskDefinition = null;
 
         if(taskDefinitions.size() > 0) {
             describeTaskDefinition = client.describeTaskDefinition(new DescribeTaskDefinitionRequest().withTaskDefinition(taskDefinitions.getLast()));
-        
+
             templateMatchesExistingContainerDefinition = def.equals(describeTaskDefinition.getTaskDefinition().getContainerDefinitions().get(0));
             LOGGER.log(Level.INFO, "Match on container defintion: {0}", new Object[] {templateMatchesExistingContainerDefinition});
             LOGGER.log(Level.FINE, "Match on container defintion: {0}; template={1}; last={2}", new Object[] {templateMatchesExistingContainerDefinition, def, describeTaskDefinition.getTaskDefinition().getContainerDefinitions().get(0)});
-            
+
             templateMatchesExistingVolumes = ObjectUtils.equals(template.getVolumeEntries(), describeTaskDefinition.getTaskDefinition().getVolumes());
             LOGGER.log(Level.INFO, "Match on volumes: {0}", new Object[] {templateMatchesExistingVolumes});
             LOGGER.log(Level.FINE, "Match on volumes: {0}; template={1}; last={2}", new Object[] {templateMatchesExistingVolumes, template.getVolumeEntries(), describeTaskDefinition.getTaskDefinition().getVolumes()});
@@ -220,20 +221,29 @@ class ECSService {
             templateMatchesExistingTaskRole = template.getTaskrole() == null || template.getTaskrole().equals(describeTaskDefinition.getTaskDefinition().getTaskRoleArn());
             LOGGER.log(Level.INFO, "Match on task role: {0}", new Object[] {templateMatchesExistingTaskRole});
             LOGGER.log(Level.FINE, "Match on task role: {0}; template={1}; last={2}", new Object[] {templateMatchesExistingTaskRole, template.getTaskrole(), describeTaskDefinition.getTaskDefinition().getTaskRoleArn()});
+
+            templateMatchesExistingExecutionRole = template.getExecutionRole() == null || template.getExecutionRole().equals(describeTaskDefinition.getTaskDefinition().getExecutionRoleArn());
+            LOGGER.log(Level.INFO, "Match on execution role: {0}", new Object[] {templateMatchesExistingExecutionRole});
+            LOGGER.log(Level.FINE, "Match on execution role: {0}; template={1}; last={2}", new Object[] {templateMatchesExistingExecutionRole, template.getExecutionRole(), describeTaskDefinition.getTaskDefinition().getExecutionRoleArn()});
         }
-        
+
         if(templateMatchesExistingContainerDefinition && templateMatchesExistingVolumes && templateMatchesExistingTaskRole) {
             LOGGER.log(Level.FINE, "Task Definition already exists: {0}", new Object[]{describeTaskDefinition.getTaskDefinition().getTaskDefinitionArn()});
             return describeTaskDefinition.getTaskDefinition().getTaskDefinitionArn();
         } else {
-            final RegisterTaskDefinitionRequest request = new RegisterTaskDefinitionRequest()                
+            final RegisterTaskDefinitionRequest request = new RegisterTaskDefinitionRequest()
                     .withFamily(familyName)
                     .withVolumes(template.getVolumeEntries())
                     .withContainerDefinitions(def);
-            
+
             if (template.getTaskrole() != null) {
                 request.withTaskRoleArn(template.getTaskrole());
-            }            
+            }
+
+            if (template.getExecutionRole() != null) {
+                request.withExecutionRoleArn(template.getExecutionRole());
+            }
+
             final RegisterTaskDefinitionResult result = client.registerTaskDefinition(request);
             String taskDefinitionArn = result.getTaskDefinition().getTaskDefinitionArn();
             LOGGER.log(Level.FINE, "Created Task Definition {0}: {1}", new Object[]{taskDefinitionArn, request});

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -143,6 +143,16 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      */
     @CheckForNull
     private String taskrole;
+
+
+    /** ARN of the task execution role that the Amazon ECS container
+     *  agent and the Docker daemon can assume
+     *
+     * @see RegisterTaskDefinitionRequest#withExecutionRoleArn(String)
+     */
+    @CheckForNull
+    private String executionRole;
+
     /**
       JVM arguments to start slave.jar
      */
@@ -218,6 +228,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     }
 
     @DataBoundSetter
+    public void setExecutionRole(String executionRoleArn) {
+        this.executionRole = StringUtils.trimToNull(executionRoleArn);
+    }
+
+    @DataBoundSetter
     public void setEntrypoint(String entrypoint) {
         this.entrypoint = StringUtils.trimToNull(entrypoint);
     }
@@ -271,6 +286,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     public String getTaskrole() {
         return taskrole;
+    }
+
+    public String getExecutionRole() {
+        return executionRole;
     }
 
     public String getJvmArgs() {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -53,6 +53,9 @@
     <f:entry title="${%Task Role ARN}" field="taskrole">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Execution Role ARN}" field="executionRole">
+      <f:textbox />
+    </f:entry>
     <f:entry title="${%Override entrypoint}" field="entrypoint">
       <f:textbox />
     </f:entry>


### PR DESCRIPTION
Allows for specifying the Task Execution Role which is required for a few different ECS scenarios:
  * Calls to Amazon ECR to pull the container image
  * Calls to CloudWatch to store container application logs (i.e. using the awslogs driver)
