### PR TITLE
Fix link to EC2 plugin wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This Jenkins plugin do use [Amazon EC2 Container Service](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/Welcome.html) to host jobs execution inside docker containers.
 
-* see [Jenkins wiki](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin) for detailed feature descriptions
+* see [Jenkins wiki](https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Container+Service+Plugin) for detailed feature descriptions
 * use [JIRA](https://issues.jenkins-ci.org/issues/?jql=project %3D JENKINS AND status in (Open%2C "In Progress"%2C Reopened) AND component %3D amazon-ecs-plugin) to report issues / feature requests
 
 


### PR DESCRIPTION
I believe the link to the Git plugin is a copy-paste mistake.