### PR TITLE
removing initialization of containerUser in ECSTaskTemplate 

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -199,8 +199,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
                            int memory,
                            int memoryReservation,
                            int cpu,
-                           boolean privileged,
-                           @Nullable String containerUser,
+                           boolean privileged,                           
                            @Nullable List<LogDriverOption> logDriverOptions,
                            @Nullable List<EnvironmentEntry> environments,
                            @Nullable List<ExtraHostEntry> extraHosts,
@@ -216,8 +215,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         this.memory = memory;
         this.memoryReservation = memoryReservation;
         this.cpu = cpu;
-        this.privileged = privileged;
-        this.containerUser = containerUser;
+        this.privileged = privileged;        
         this.logDriverOptions = logDriverOptions;
         this.environments = environments;
         this.extraHosts = extraHosts;


### PR DESCRIPTION
Recent pull request https://github.com/jenkinsci/amazon-ecs-plugin/pull/49, added containerUser field, initialization would cause it to default to an empty string instead of the expected null value, causing templates without a containerUser to fail, making it a required value.

Should fix https://github.com/cloudbees/amazon-ecs-plugin/issues/14 as well