### PR TITLE
Treat empty username as null

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -217,7 +217,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
         this.memoryReservation = memoryReservation;
         this.cpu = cpu;
         this.privileged = privileged;
-        this.containerUser = containerUser;
+        this.containerUser = StringUtils.trimToNull(containerUser);
         this.logDriverOptions = logDriverOptions;
         this.environments = environments;
         this.extraHosts = extraHosts;


### PR DESCRIPTION
Fixes the issue:
```
WARNING: Unexpected exception encountered while provisioning agent ECS Slave generic
com.amazonaws.services.ecs.model.ClientException: The user value contains invalid characters. Enter a value that matches the pattern ^([a-z0-9_][a-z0-9_-]{0,30})$ (Service: AmazonECS; Status Code: 400;
```