### PR TITLE
Fix readme.md to use proper wiki URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This Jenkins plugin do use [Amazon EC2 Container Service](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/Welcome.html) to host jobs execution inside docker containers.
 
 * see [Jenkins wiki](https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Container+Service+Plugin) for detailed feature descriptions
-* use [JIRA](https://issues.jenkins-ci.org/issues/?jql=project %3D JENKINS AND status in (Open%2C "In Progress"%2C Reopened) AND component %3D amazon-ecs-plugin) to report issues / feature requests
+* use [JIRA](https://issues.jenkins-ci.org/issues/?jql=project%3DJENKINS%20AND%20status%20in%28Open%2C"In%20Progress"%2CReopened%29AND%20component%3Damazon-ecs-plugin) to report issues / feature requests
 
 
 ## Building the Plugin


### PR DESCRIPTION



The readme doesn't render properly - this updates the URL that points to the jira project so that it will render correctly.

Before:
![1 bash 2018-04-16 16-00-11](https://user-images.githubusercontent.com/3365/38839405-48448330-418f-11e8-935c-ec30402b3f97.png)
After:
![1 bash 2018-04-16 15-59-44](https://user-images.githubusercontent.com/3365/38839385-3020ae96-418f-11e8-874b-922516b508b8.png)
