### PR TITLE
Added executionRole field for fargate support

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -213,6 +213,7 @@ class ECSService {
         boolean templateMatchesExistingContainerDefinition = false;
         boolean templateMatchesExistingVolumes = false;
         boolean templateMatchesExistingTaskRole = false;
+        boolean templateMatchesExistingExecutionRole = false;
 
         if (currentTaskDefinition != null) {
             templateMatchesExistingContainerDefinition = def.equals(currentTaskDefinition.getContainerDefinitions().get(0));
@@ -226,9 +227,13 @@ class ECSService {
             templateMatchesExistingTaskRole = template.getTaskrole() == null || template.getTaskrole().equals(currentTaskDefinition.getTaskRoleArn());
             LOGGER.log(Level.INFO, "Match on task role: {0}", new Object[] {templateMatchesExistingTaskRole});
             LOGGER.log(Level.FINE, "Match on task role: {0}; template={1}; last={2}", new Object[] {templateMatchesExistingTaskRole, template.getTaskrole(), currentTaskDefinition.getTaskRoleArn()});
+
+            templateMatchesExistingExecutionRole = template.getExecutionRole() == null || template.getExecutionRole().equals(currentTaskDefinition.getExecutionRoleArn());
+            LOGGER.log(Level.INFO, "Match on execution role: {0}", new Object[] {templateMatchesExistingExecutionRole});
+            LOGGER.log(Level.FINE, "Match on execution role: {0}; template={1}; last={2}", new Object[] {templateMatchesExistingExecutionRole, template.getExecutionRole(), currentTaskDefinition.getExecutionRoleArn()});
         }
         
-        if(templateMatchesExistingContainerDefinition && templateMatchesExistingVolumes && templateMatchesExistingTaskRole) {
+        if(templateMatchesExistingContainerDefinition && templateMatchesExistingVolumes && templateMatchesExistingTaskRole && templateMatchesExistingExecutionRole) {
             LOGGER.log(Level.FINE, "Task Definition already exists: {0}", new Object[]{currentTaskDefinition.getTaskDefinitionArn()});
             return currentTaskDefinition;
         } else {
@@ -244,11 +249,9 @@ class ECSService {
                         .withMemory(String.valueOf(template.getMemoryConstraint()))
                         .withCpu(String.valueOf(template.getCpu()));
                 String executionRole = template.getExecutionRole();
-                if(StringUtils.isEmpty(executionRole)){
-                    executionRole = ECSTaskTemplate.DEFAULT_ECS_TASK_EXECUTION_IAM_ROLE_NAME;
-                    LOGGER.log(Level.FINE, "executionRole was not provided, falling back to default: {0}", executionRole);
+                if(!StringUtils.isEmpty(executionRole)){
+                    request.withExecutionRoleArn(executionRole);
                 }
-                request.withExecutionRoleArn(executionRole);
             }
             if (template.getTaskrole() != null) {
                 request.withTaskRoleArn(template.getTaskrole());

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -243,6 +243,12 @@ class ECSService {
                         .withNetworkMode("awsvpc")
                         .withMemory(String.valueOf(template.getMemoryConstraint()))
                         .withCpu(String.valueOf(template.getCpu()));
+                String executionRole = template.getExecutionRole();
+                if(StringUtils.isEmpty(executionRole)){
+                    executionRole = ECSTaskTemplate.DEFAULT_ECS_TASK_EXECUTION_IAM_ROLE_NAME;
+                    LOGGER.log(Level.FINE, "executionRole was not provided, falling back to default: {0}", executionRole);
+                }
+                request.withExecutionRoleArn(executionRole);
             }
             if (template.getTaskrole() != null) {
                 request.withTaskRoleArn(template.getTaskrole());

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -62,8 +62,6 @@ import java.util.*;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
-    public static final String DEFAULT_ECS_TASK_EXECUTION_IAM_ROLE_NAME = "ecsTaskExecutionRole";
-
     /**
      * Template Name
      */

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -62,6 +62,7 @@ import java.util.*;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
+    public static final String DEFAULT_ECS_TASK_EXECUTION_IAM_ROLE_NAME = "ecsTaskExecutionRole";
 
     /**
      * Template Name
@@ -177,6 +178,15 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      */
     @CheckForNull
     private String taskrole;
+
+    /**
+     * ARN of the IAM role to use for the slave ECS task
+     *
+     * @see RegisterTaskDefinitionRequest#withExecutionRoleArn(String)
+     */
+    @CheckForNull
+    private String executionRole;
+
     /**
       JVM arguments to start slave.jar
      */
@@ -289,6 +299,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
     }
 
     @DataBoundSetter
+    public void setExecutionRole(String executionRole) {
+        this.executionRole = StringUtils.trimToNull(executionRole);
+    }
+
+    @DataBoundSetter
     public void setEntrypoint(String entrypoint) {
         this.entrypoint = StringUtils.trimToNull(entrypoint);
     }
@@ -373,6 +388,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     public String getTaskrole() {
         return taskrole;
+    }
+
+    public String getExecutionRole() {
+        return executionRole;
     }
 
     public String getJvmArgs() {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -68,6 +68,9 @@
     <f:entry title="${%Task Role ARN}" field="taskrole">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Task Execution Role ARN}" field="executionRole">
+      <f:textbox />
+    </f:entry>
     <f:entry title="${%Override entrypoint}" field="entrypoint">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -69,7 +69,7 @@
       <f:textbox />
     </f:entry>
     <f:entry title="${%Task Execution Role ARN}" field="executionRole">
-      <f:textbox />
+      <f:textbox default="ecsTaskExecutionRole"/>
     </f:entry>
     <f:entry title="${%Override entrypoint}" field="entrypoint">
       <f:textbox />

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-executionRole.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-executionRole.html
@@ -1,0 +1,36 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+<p>
+    The Amazon ECS container agent makes calls to the Amazon ECS API actions on your behalf,
+    so it requires an IAM policy and role for the service to know that the agent belongs to you
+</p>
+<p>
+    Only relevant for FARGATE. If not specified, the plugin will try to use the default <b>ecsTaskExecutionRole</b> role
+</p>
+<p>
+    See <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html">ECS Task Execution IAM Role</a> for
+    more details about task execution roles.
+</p>


### PR DESCRIPTION
Hi,
I've taken the latest version and tried to run the FARGATE launch type.
Followed all the FARGATE rules, but got the following exception:
```
com.amazonaws.services.ecs.model.ClientException: Fargate requires task definition to have execution role ARN to support ECR images. (Service: AmazonECS; Status Code: 400; Error Code: ClientException; Request ID: f8232776-6025-11e8-9c16-339a4240ed65)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1639)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1304)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1056)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:743)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:717)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:699)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:667)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:649)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:513)
	at com.amazonaws.services.ecs.AmazonECSClient.doInvoke(AmazonECSClient.java:2701)
	at com.amazonaws.services.ecs.AmazonECSClient.invoke(AmazonECSClient.java:2677)
	at com.amazonaws.services.ecs.AmazonECSClient.executeRegisterTaskDefinition(AmazonECSClient.java:1912)
	at com.amazonaws.services.ecs.AmazonECSClient.registerTaskDefinition(AmazonECSClient.java:1887)
	at com.cloudbees.jenkins.plugins.amazonecs.ECSService.registerTemplate(ECSService.java:250)
	at com.cloudbees.jenkins.plugins.amazonecs.ECSCloud$ProvisioningCallback.call(ECSCloud.java:264)
	at com.cloudbees.jenkins.plugins.amazonecs.ECSCloud$ProvisioningCallback.call(ECSCloud.java:227)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

After investigation, I've found out that the reason for that is the [Execution IAM Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html) is never provided when creating a task execution request. Not sure how it works for other people, but created this PR for adding it to the configuration and if FARGATE is being used, it will either put the provided value or will use the default `ecsTaskExecutionRole` role that is created automatically by Amazon.

I really want to use the official plugin, but at the moment, I cannot because of that.

Cheers,
Ohad 