### PR TITLE
Delete Task if it failed to connect during provisioning

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -303,6 +303,7 @@ public class ECSCloud extends Cloud {
                 final String msg = MessageFormat.format("ECS Slave {0} (ecs task {1}) not connected since {2} seconds",
                         slave.getNodeName(), slave.getTaskArn(), now);
                 LOGGER.log(Level.WARNING, msg);
+                deleteTask(slave.getTaskArn(), slave.getClusterArn());
                 Jenkins.getInstance().removeNode(slave);
                 throw new IllegalStateException(msg);
             }


### PR DESCRIPTION
When an agent is being provisioned, the ECSCloud starts the ECS task which runs the agent and waits for the agent to become online. If the agent does not become online, then the agent is removed from Jenkins. However, in some cases the ECS task may still be running which leaks cluster resources. For example, we have observed JNLP agents which have hung during startup and continue to run but not connect.

This PR terminates the task if it did not become online during provisioning, preventing leaking of cluster resources from failed provisioning attempts.

If the task is not running, then `deleteTask` simply logs and continues.