### PR TITLE
WIP: Adding Pipeline Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.609</version>
+		<version>3.12</version>
 		<relativePath />
 	</parent>
 
@@ -32,6 +32,13 @@
 	<name>Amazon EC2 Container Service plugin</name>
 	<description>Jenkins plugin to run dynamic slaves in a Amazon ECS/Docker environment</description>
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Container+Service+Plugin</url>
+
+	<scm>
+		<connection>scm:git:git://github.com/jenkinsci/amazon-ecs-plugin.git</connection>
+		<developerConnection>scm:git:git@github.com:jenkinsci/amazon-ecs-plugin.git</developerConnection>
+		<url>https://github.com/jenkinsci/amazon-ecs-plugin</url>
+		<tag>HEAD</tag>
+	</scm>
 
 	<developers>
 		<developer>
@@ -51,25 +58,11 @@
 		</developer>
 	</developers>
 
-	<scm>
-		<connection>scm:git:git://github.com/jenkinsci/amazon-ecs-plugin.git</connection>
-		<developerConnection>scm:git:git@github.com:jenkinsci/amazon-ecs-plugin.git</developerConnection>
-		<url>https://github.com/jenkinsci/amazon-ecs-plugin</url>
-		<tag>amazon-ecs-1.12</tag>
-	</scm>
-
-	<repositories>
-		<repository>
-			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
-		</pluginRepository>
-	</pluginRepositories>
+  <properties>
+    <java.level>8</java.level>
+    <jenkins.version>2.107.3</jenkins.version>
+    <no-test-jar>false</no-test-jar>
+  </properties>
 
 	<distributionManagement>
 		<repository>
@@ -86,13 +79,122 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>aws-java-sdk</artifactId>
-			<version>1.11.264</version>
+			<version>1.11.341</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>aws-credentials</artifactId>
 			<version>1.23</version>
 		</dependency>
+		<dependency> <!-- DeclarativeAgent -->
+			<groupId>org.jenkinsci.plugins</groupId>
+			<artifactId>pipeline-model-extensions</artifactId>
+			<version>1.1.2</version>
+			<optional>true</optional>
+		</dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>variant</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.11</version>
+    </dependency>
+    <dependency> <!-- OnceRetentionStrategy -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>durable-task</artifactId>
+      <version>1.16</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.10.0</version>
+      <scope>test</scope>
+    </dependency>
 	</dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>2.1.16</version>
+      </dependency>
+
+      <!-- just to fix enforcer RequireUpperBoundDeps -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials-binding</artifactId>
+        <version>1.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>structs</artifactId>
+        <version>1.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>ssh-credentials</artifactId>
+        <version>1.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-core</artifactId>
+        <version>1.7.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <hudson.slaves.NodeProvisioner.initialDelay>0</hudson.slaves.NodeProvisioner.initialDelay>
+            <hudson.slaves.NodeProvisioner.MARGIN>50</hudson.slaves.NodeProvisioner.MARGIN>
+            <hudson.slaves.NodeProvisioner.MARGIN0>0.85</hudson.slaves.NodeProvisioner.MARGIN0>
+            <!-- listen in this interface for connections from kubernetes pods -->
+            <connectorHost>${connectorHost}</connectorHost>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <!-- with the default setting seems that an older version of jackson from core is used
+            java.lang.NoSuchMethodError: com.fasterxml.jackson.core.JsonFactory.requiresPropertyOrdering()Z
+            at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:549)
+            at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:460)
+            at io.fabric8.kubernetes.client.utils.Serialization.<clinit>(Serialization.java:37)
+          -->
+          <pluginFirstClassLoader>true</pluginFirstClassLoader>
+          <systemProperties>
+            <hudson.slaves.NodeProvisioner.initialDelay>0</hudson.slaves.NodeProvisioner.initialDelay>
+            <hudson.slaves.NodeProvisioner.MARGIN>50</hudson.slaves.NodeProvisioner.MARGIN>
+            <hudson.slaves.NodeProvisioner.MARGIN0>0.85</hudson.slaves.NodeProvisioner.MARGIN0>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+	<repositories>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 </project>

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -26,22 +26,17 @@
 package com.cloudbees.jenkins.plugins.amazonecs;
 
 import java.io.IOException;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 
-import com.amazonaws.services.ecs.model.TaskDefinition;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -50,10 +45,6 @@ import org.kohsuke.stapler.QueryParameter;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.ecs.AmazonECSClient;
-import com.amazonaws.services.ecs.model.ListClustersRequest;
-import com.amazonaws.services.ecs.model.ListClustersResult;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 
@@ -61,9 +52,7 @@ import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Label;
-import hudson.model.Node;
 import hudson.slaves.Cloud;
-import hudson.slaves.JNLPLauncher;
 import hudson.slaves.NodeProvisioner;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
@@ -76,9 +65,7 @@ import jenkins.model.JenkinsLocationConfiguration;
 public class ECSCloud extends Cloud {
 
     private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
-
     private static final int DEFAULT_SLAVE_TIMEOUT = 900;
-
     private final List<ECSTaskTemplate> templates;
 
     /**
@@ -86,9 +73,7 @@ public class ECSCloud extends Cloud {
      */
     @Nonnull
     private final String credentialsId;
-
     private final String cluster;
-
     private String regionName;
 
     /**
@@ -96,50 +81,24 @@ public class ECSCloud extends Cloud {
      */
     @CheckForNull
     private String tunnel;
-
     private String jenkinsUrl;
-
     private int slaveTimoutInSeconds;
-
     private ECSService ecsService;
 
     @DataBoundConstructor
     public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId,
-            String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds) throws InterruptedException{
+                    String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds) throws InterruptedException{
         super(name);
+
+        LOGGER.log(Level.INFO, "Create cloud {0} on ECS cluster {1} on the region {2}", new Object[]{name, cluster, regionName});
+
         this.credentialsId = credentialsId;
         this.cluster = cluster;
         this.templates = templates;
         this.regionName = regionName;
-        LOGGER.log(Level.INFO, "Create cloud {0} on ECS cluster {1} on the region {2}", new Object[]{name, cluster, regionName});
 
-        if(StringUtils.isNotBlank(jenkinsUrl)) {
-            this.jenkinsUrl = jenkinsUrl;
-        } else {
-            this.jenkinsUrl = JenkinsLocationConfiguration.get().getUrl();
-        }
-
-        if(slaveTimoutInSeconds > 0) {
-            this.slaveTimoutInSeconds = slaveTimoutInSeconds;
-        } else {
-            this.slaveTimoutInSeconds = DEFAULT_SLAVE_TIMEOUT;
-        }
-    }
-
-    synchronized ECSService getEcsService() {
-        if (ecsService == null) {
-            ecsService = new ECSService(credentialsId, regionName);
-        }
-        return ecsService;
-    }
-
-    AmazonECSClient getAmazonECSClient() {
-        return getEcsService().getAmazonECSClient();
-    }
-
-    @Nonnull
-    public List<ECSTaskTemplate> getTemplates() {
-        return templates != null ? templates : Collections.<ECSTaskTemplate> emptyList();
+        this.jenkinsUrl = (StringUtils.isNotBlank(jenkinsUrl)) ? jenkinsUrl : JenkinsLocationConfiguration.get().getUrl();
+        this.slaveTimoutInSeconds = (slaveTimoutInSeconds > 0) ? slaveTimoutInSeconds : DEFAULT_SLAVE_TIMEOUT;
     }
 
     public String getCredentialsId() {
@@ -167,14 +126,57 @@ public class ECSCloud extends Cloud {
         this.tunnel = tunnel;
     }
 
-    @CheckForNull
-    private static AmazonWebServicesCredentials getCredentials(@Nullable String credentialsId) {
-        return AWSCredentialsHelper.getCredentials(credentialsId, Jenkins.getActiveInstance());
+    public int getSlaveTimoutInSeconds() {
+        return slaveTimoutInSeconds;
+    }
+
+    public void setSlaveTimoutInSeconds(int slaveTimoutInSeconds) {
+        this.slaveTimoutInSeconds = slaveTimoutInSeconds;
+    }
+
+    public String getJenkinsUrl() {
+        return jenkinsUrl;
+    }
+
+    public void setJenkinsUrl(String jenkinsUrl) {
+        this.jenkinsUrl = jenkinsUrl;
+    }
+
+    @Nonnull
+    public List<ECSTaskTemplate> getTemplates() {
+        return templates != null ? templates : Collections.<ECSTaskTemplate> emptyList();
     }
 
     @Override
     public boolean canProvision(Label label) {
         return getTemplate(label) != null;
+    }
+
+    @Override
+    public Collection<NodeProvisioner.PlannedNode> provision(Label label, int excessWorkload) {
+        try {
+			LOGGER.log(Level.INFO, "Asked to provision {0} slave(s) for: {1}", new Object[]{excessWorkload, label});
+
+            List<NodeProvisioner.PlannedNode> plannedNodes = new ArrayList<NodeProvisioner.PlannedNode>();
+            final ECSTaskTemplate template = getTemplate(label);
+
+            for (int i = 1; i <= excessWorkload; i++) {
+				LOGGER.log(Level.INFO, "Will provision {0}, for label: {1}", new Object[]{template.getDisplayName(), label} );
+
+                plannedNodes.add(new NodeProvisioner.PlannedNode(
+                    template.getDisplayName(), 
+                    Computer.threadPoolForRemoting.submit(new ProvisioningCallback(this, getEcsService(), template)), 
+                    1));
+            }
+            return plannedNodes;
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to provision ECS slave", e);
+            return Collections.emptyList();
+        }
+    }
+
+    public void deleteTask(String taskArn, String clusterArn) {
+        getEcsService().deleteTask(taskArn, clusterArn);
     }
 
     private ECSTaskTemplate getTemplate(Label label) {
@@ -189,143 +191,12 @@ public class ECSCloud extends Cloud {
         return null;
     }
 
-
-    @Override
-    public Collection<NodeProvisioner.PlannedNode> provision(Label label, int excessWorkload) {
-        try {
-			LOGGER.log(Level.INFO, "Asked to provision {0} slave(s) for: {1}", new Object[]{excessWorkload, label});
-
-            List<NodeProvisioner.PlannedNode> r = new ArrayList<NodeProvisioner.PlannedNode>();
-            final ECSTaskTemplate template = getTemplate(label);
-
-            for (int i = 1; i <= excessWorkload; i++) {
-				LOGGER.log(Level.INFO, "Will provision {0}, for label: {1}", new Object[]{template.getDisplayName(), label} );
-
-                r.add(new NodeProvisioner.PlannedNode(template.getDisplayName(), Computer.threadPoolForRemoting
-                  .submit(new ProvisioningCallback(template, label)), 1));
-            }
-            return r;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to provision ECS slave", e);
-            return Collections.emptyList();
+    private synchronized ECSService getEcsService() {
+        if (ecsService == null) {
+            ecsService = new ECSService(this.credentialsId, this.regionName);
         }
+        return ecsService;
     }
-
-     void deleteTask(String taskArn, String clusterArn) {
-        getEcsService().deleteTask(taskArn, clusterArn);
-    }
-
-    public int getSlaveTimoutInSeconds() {
-        return slaveTimoutInSeconds;
-    }
-
-    public void setSlaveTimoutInSeconds(int slaveTimoutInSeconds) {
-        this.slaveTimoutInSeconds = slaveTimoutInSeconds;
-    }
-
-
-    private class ProvisioningCallback implements Callable<Node> {
-
-        private final ECSTaskTemplate template;
-        @CheckForNull
-        private Label label;
-
-        public ProvisioningCallback(ECSTaskTemplate template, @Nullable Label label) {
-            this.template = template;
-            this.label = label;
-        }
-
-        public Node call() throws Exception {
-            final ECSSlave slave;
-
-            Date now = new Date();
-            Date timeout = new Date(now.getTime() + 1000 * slaveTimoutInSeconds);
-
-            synchronized (cluster) {
-                if (!template.isFargate()){
-                    getEcsService().waitForSufficientClusterResources(timeout, template, cluster);
-                }
-
-
-                String uniq = Long.toHexString(System.nanoTime());
-                slave = new ECSSlave(ECSCloud.this, name + "-" + uniq, template.getRemoteFSRoot(),
-                        template.getLabel(), new JNLPLauncher());
-                slave.setClusterArn(cluster);
-                Jenkins.getInstance().addNode(slave);
-                while (Jenkins.getInstance().getNode(slave.getNodeName()) == null) {
-                    Thread.sleep(1000);
-                }
-                LOGGER.log(Level.INFO, "Created Slave: {0}", slave.getNodeName());
-
-                try {
-                    TaskDefinition taskDefinition;
-
-                    if (template.getTaskDefinitionOverride() == null) {
-                        taskDefinition = getEcsService().registerTemplate(slave.getCloud(), template);
-                    } else {
-                        LOGGER.log(Level.FINE, "Attempting to find task definition family or ARN: {0}", template.getTaskDefinitionOverride());
-
-                        taskDefinition = getEcsService().findTaskDefinition(template.getTaskDefinitionOverride());
-                        if (taskDefinition == null) {
-                            throw new RuntimeException("Could not find task definition family or ARN: " + template.getTaskDefinitionOverride());
-                        }
-
-                        LOGGER.log(Level.FINE, "Found task definition: {0}", taskDefinition.getTaskDefinitionArn());
-                    }
-
-                    LOGGER.log(Level.INFO, "Running task definition {0} on slave {1}", new Object[]{taskDefinition.getTaskDefinitionArn(), slave.getNodeName()});
-
-                    String taskArn = getEcsService().runEcsTask(slave, template, cluster, getDockerRunCommand(slave), taskDefinition);
-                    LOGGER.log(Level.INFO, "Slave {0} - Slave Task Started : {1}",
-                            new Object[] { slave.getNodeName(), taskArn });
-                    slave.setTaskArn(taskArn);
-                } catch (Exception ex) {
-                    LOGGER.log(Level.WARNING, "Slave {0} - Cannot create ECS Task");
-                    Jenkins.getInstance().removeNode(slave);
-                    throw ex;
-                }
-            }
-
-            // now wait for slave to be online
-            while (timeout.after(new Date())) {
-                if (slave.getComputer() == null) {
-                    throw new IllegalStateException(
-                            "Slave " + slave.getNodeName() + " - Node was deleted, computer is null");
-                }
-                if (slave.getComputer().isOnline()) {
-                    break;
-                }
-                LOGGER.log(Level.FINE, "Waiting for slave {0} (ecs task {1}) to connect since {2}.",
-                        new Object[] { slave.getNodeName(), slave.getTaskArn(), now });
-                Thread.sleep(1000);
-            }
-            if (!slave.getComputer().isOnline()) {
-                final String msg = MessageFormat.format("ECS Slave {0} (ecs task {1}) not connected since {2} seconds",
-                        slave.getNodeName(), slave.getTaskArn(), now);
-                LOGGER.log(Level.WARNING, msg);
-                Jenkins.getInstance().removeNode(slave);
-                throw new IllegalStateException(msg);
-            }
-
-            LOGGER.log(Level.INFO, "ECS Slave " + slave.getNodeName() + " (ecs task {0}) connected",
-                    slave.getTaskArn());
-            return slave;
-        }
-    }
-
-    private Collection<String> getDockerRunCommand(ECSSlave slave) {
-        Collection<String> command = new ArrayList<String>();
-        command.add("-url");
-        command.add(jenkinsUrl);
-        if (StringUtils.isNotBlank(tunnel)) {
-            command.add("-tunnel");
-            command.add(tunnel);
-        }
-        command.add(slave.getComputer().getJnlpMac());
-        command.add(slave.getComputer().getName());
-        return command;
-    }
-
 
     @Extension
     public static class DescriptorImpl extends Descriptor<Cloud> {
@@ -338,7 +209,7 @@ public class ECSCloud extends Cloud {
         }
 
         public ListBoxModel doFillCredentialsIdItems() {
-            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.getActiveInstance());
+            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.get());
         }
 
         public ListBoxModel doFillRegionNameItems() {
@@ -352,14 +223,7 @@ public class ECSCloud extends Cloud {
         public ListBoxModel doFillClusterItems(@QueryParameter String credentialsId, @QueryParameter String regionName) {
             ECSService ecsService = new ECSService(credentialsId, regionName);
             try {
-                final AmazonECSClient client = ecsService.getAmazonECSClient();
-                final List<String> allClusterArns = new ArrayList<String>();
-                String lastToken = null;
-                do {
-                    ListClustersResult result = client.listClusters(new ListClustersRequest().withNextToken(lastToken));
-                    allClusterArns.addAll(result.getClusterArns());
-                    lastToken = result.getNextToken();
-                } while (lastToken != null);
+                final List<String> allClusterArns = ecsService.listClusters();
                 Collections.sort(allClusterArns);
                 final ListBoxModel options = new ListBoxModel();
                 for (final String arn : allClusterArns) {
@@ -383,22 +247,5 @@ public class ECSCloud extends Cloud {
             }
             return FormValidation.error("Up to 127 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed");
         }
-
-    }
-
-    public static Region getRegion(String regionName) {
-        if (StringUtils.isNotEmpty(regionName)) {
-            return RegionUtils.getRegion(regionName);
-        } else {
-            return Region.getRegion(Regions.US_EAST_1);
-        }
-    }
-
-    public String getJenkinsUrl() {
-        return jenkinsUrl;
-    }
-
-    public void setJenkinsUrl(String jenkinsUrl) {
-        this.jenkinsUrl = jenkinsUrl;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputer.java
@@ -28,9 +28,6 @@ package com.cloudbees.jenkins.plugins.amazonecs;
 import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
-import hudson.slaves.AbstractCloudSlave;
-
-import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -41,7 +38,7 @@ import java.util.logging.Logger;
  *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class ECSComputer extends AbstractCloudComputer {
+public class ECSComputer extends AbstractCloudComputer<ECSSlave> {
     private static final Logger LOGGER = Logger.getLogger(ECSComputer.class.getName());
 
     public ECSComputer(ECSSlave slave) {
@@ -51,52 +48,23 @@ public class ECSComputer extends AbstractCloudComputer {
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
         super.taskAccepted(executor, task);
-
         LOGGER.log(Level.FINE, "Computer {0} taskAccepted", this);
-        
-        // Now that we have a task, we want to make sure to tell Jenkins
-        // that this computer is no longer accepting any additional tasks.
-        setAcceptingTasks(false);
     }
 
     @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
         super.taskCompleted(executor, task, durationMS);
-        
         LOGGER.log(Level.FINE, "Computer {0} taskCompleted", this);
-        
-        terminate();
     }
 
     @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
         super.taskCompletedWithProblems(executor, task, durationMS, problems);
-        
         LOGGER.log(Level.FINE, "Computer {0} taskCompletedWithProblems", this);
-        
-        terminate();
     }
 
-    /**
-     * Computer is terminated after build completion so we enforce it will only be used once.
-     */
-    private void terminate() {
-        LOGGER.log(Level.INFO, "Attempting to terminate the node for computer: {0}", this);
-        
-        // The task has been completed, so we want to make sure to tell Jenkins
-        // that this computer is no longer accepting tasks.
-        AbstractCloudSlave node = getNode();
-        if( node != null ) {
-            LOGGER.log(Level.INFO, "Terminating the node for computer: {0}", this);
-            try {
-                node.terminate();
-            } catch (InterruptedException e) {
-                LOGGER.log(Level.WARNING, "Failed to terminate computer: " + getName(), e);
-            } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Failed to terminate computer: " + getName(), e);
-            }
-        } else {
-            LOGGER.log(Level.WARNING, "There is no node for computer: {0}", this);
-        }
+    @Override
+    public String toString() {
+        return String.format("ECSComputer name: %s slave: %s", getName(), getNode());
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -27,22 +27,17 @@ package com.cloudbees.jenkins.plugins.amazonecs;
 
 import java.io.IOException;
 import java.util.Collections;
-
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
+
+import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
 
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
-import hudson.node_monitors.ResponseTimeMonitor;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.ComputerLauncher;
-import hudson.slaves.RetentionStrategy;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * This slave should only handle a single task and then be shutdown.
@@ -51,7 +46,7 @@ import java.util.logging.Logger;
  */
 public class ECSSlave extends AbstractCloudSlave {
 
-    private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
+    private static final long serialVersionUID = 1;
 
     @Nonnull
     private final ECSCloud cloud;
@@ -70,63 +65,12 @@ public class ECSSlave extends AbstractCloudSlave {
     @CheckForNull
     private String taskArn;
 
-    private static RetentionStrategy deleteAfterFinished = new RetentionStrategy<ECSComputer>() {
-        @Override
-        public boolean isManualLaunchAllowed(ECSComputer c) {
-            return false;
-        }
-
-        @Override
-        @GuardedBy("hudson.model.Queue.lock")
-        public long check(ECSComputer c) {
-            LOGGER.log(Level.FINE, "Checking computer: {0}", c);
-
-            AbstractCloudSlave node = c.getNode();
-
-            // If the computer is NOT idle, then it is currently running some task.
-            // In this case, we are going to tell Jenkins that it can no longer accept
-            // any new tasks, which will cause it to create a new node for any subsequent
-            // tasks.
-            if(!c.isIdle() ) {
-                LOGGER.log(Level.FINE, "Computer is not idle; setting it to no longer accept tasks.");
-                c.setAcceptingTasks( false );
-            }
-
-            // If the computer IS idle AND it is no longer accepting tasks, then it has
-            // already had a task and completed it.  In this case, we are going to terminate
-            // the node.
-            if(c.isIdle() && !c.isAcceptingTasks() && node != null) {
-                LOGGER.log(Level.FINE, "Computer is idle and not accepting tasks; terminating it.");
-                try {
-                    node.terminate();
-                } catch (InterruptedException e) {
-                    LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
-                }
-            }
-
-            // If the Response Time Monitor has marked this computer as not responding, then
-            // we are going to terminate the node to free up resources.
-            if (c.getOfflineCause() instanceof ResponseTimeMonitor.Data && node != null) {
-                LOGGER.log(Level.FINE, "Computer is not responding; terminating it");
-                try {
-                    node.terminate();
-                } catch (InterruptedException e) {
-                    LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
-                }
-            }
-
-            // Tell Jenkins to check again in 1 minute.
-            return 1;
-        }
-
-    };
-
-    public ECSSlave(@Nonnull ECSCloud cloud, @Nonnull String name, @Nullable String remoteFS, @Nullable String labelString, @Nonnull ComputerLauncher launcher) throws Descriptor.FormException, IOException {
-        super(name, "ECS slave", remoteFS, 1, Mode.EXCLUSIVE, labelString, launcher, deleteAfterFinished, Collections.EMPTY_LIST);
+    public ECSSlave(@Nonnull ECSCloud cloud, 
+                    @Nonnull String name, 
+                    @Nullable String remoteFS, 
+                    @Nullable String labelString, 
+                    @Nonnull ComputerLauncher launcher) throws Descriptor.FormException, IOException {
+        super(name, "ECS slave", remoteFS, 1, Mode.EXCLUSIVE, labelString, launcher, new OnceRetentionStrategy(5), Collections.emptyList());
         this.cloud = cloud;
     }
 
@@ -155,7 +99,7 @@ public class ECSSlave extends AbstractCloudSlave {
     }
 
     @Override
-    public AbstractCloudComputer createComputer() {
+    public AbstractCloudComputer<ECSSlave> createComputer() {
         return new ECSComputer(this);
     }
 
@@ -164,6 +108,11 @@ public class ECSSlave extends AbstractCloudSlave {
         if (taskArn != null) {
             cloud.deleteTask(taskArn, clusterArn);
         }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ECSSlave name: %s", name);
     }
 
     public ECSCloud getCloud() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -35,7 +35,6 @@ import com.amazonaws.services.ecs.model.KeyValuePair;
 import com.amazonaws.services.ecs.model.LaunchType;
 import com.amazonaws.services.ecs.model.MountPoint;
 import com.amazonaws.services.ecs.model.RegisterTaskDefinitionRequest;
-import com.amazonaws.services.ecs.model.Volume;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -44,7 +43,6 @@ import hudson.model.labels.LabelAtom;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
-import hudson.util.ListBoxModel;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ProvisioningCallback.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ProvisioningCallback.java
@@ -1,0 +1,99 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.amazonaws.services.ecs.model.TaskDefinition;
+import org.apache.commons.lang.StringUtils;
+
+import hudson.model.Node;
+import hudson.slaves.JNLPLauncher;
+import jenkins.model.Jenkins;
+
+
+public class ProvisioningCallback implements Callable<Node> {
+
+    private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
+
+    private final ECSCloud cloud;
+    private final ECSService ecs;
+    private final ECSTaskTemplate template;
+
+    public ProvisioningCallback(ECSCloud cloud, ECSService ecs, ECSTaskTemplate template) {
+        this.cloud = cloud;
+        this.template = template;
+        this.ecs = ecs;
+    }
+
+    public Node call() throws Exception {
+        final ECSSlave slave;
+
+        Date now = new Date();
+        Date timeout = new Date(now.getTime() + 1000 * cloud.getSlaveTimoutInSeconds());
+
+        synchronized (cloud.getCluster()) {
+            if (!template.isFargate()){
+                ecs.waitForSufficientClusterResources(timeout, template, cloud.getCluster());
+            }
+
+            String uniq = Long.toHexString(System.nanoTime());
+            slave = new ECSSlave(cloud, cloud.name + "-" + uniq, template.getRemoteFSRoot(),
+                    template.getLabel(), new JNLPLauncher(false));
+
+            slave.setClusterArn(cloud.getCluster());
+            Jenkins.get().addNode(slave);
+
+            while (Jenkins.get().getNode(slave.getNodeName()) == null) {
+                Thread.sleep(1000);
+            }
+            LOGGER.log(Level.INFO, "Created Slave: {0}", slave.getNodeName());
+
+            try {
+                TaskDefinition taskDefinition;
+
+                if (template.getTaskDefinitionOverride() == null) {
+                    taskDefinition = ecs.registerTemplate(slave.getCloud(), template);
+                } else {
+                    LOGGER.log(Level.FINE, "Attempting to find task definition family or ARN: {0}", template.getTaskDefinitionOverride());
+
+                    taskDefinition = ecs.findTaskDefinition(template.getTaskDefinitionOverride());
+                    if (taskDefinition == null) {
+                        throw new RuntimeException("Could not find task definition family or ARN: " + template.getTaskDefinitionOverride());
+                    }
+
+                    LOGGER.log(Level.FINE, "Found task definition: {0}", taskDefinition.getTaskDefinitionArn());
+                }
+
+                LOGGER.log(Level.INFO, "Running task definition {0} on slave {1}", new Object[]{taskDefinition.getTaskDefinitionArn(), slave.getNodeName()});
+
+                String taskArn = ecs.runEcsTask(slave, template, cloud.getCluster(), getDockerRunCommand(slave), taskDefinition);
+                LOGGER.log(Level.INFO, "Slave {0} - Slave Task Started : {1}", new Object[] { slave.getNodeName(), taskArn });
+
+                slave.setTaskArn(taskArn);
+            } catch (Exception ex) {
+                LOGGER.log(Level.WARNING, "Slave {0} - Cannot create ECS Task");
+                Jenkins.get().removeNode(slave);
+                throw ex;
+            }
+        }
+
+        return slave;
+    }
+
+    private Collection<String> getDockerRunCommand(ECSSlave slave) {
+        Collection<String> command = new ArrayList<String>();
+        command.add("-url");
+        command.add(cloud.getJenkinsUrl());
+        if (StringUtils.isNotBlank(cloud.getTunnel())) {
+            command.add("-tunnel");
+            command.add(cloud.getTunnel());
+        }
+        command.add(slave.getComputer().getJnlpMac());
+        command.add(slave.getComputer().getName());
+        return command;
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ProvisioningCallbackTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ProvisioningCallbackTest.java
@@ -1,0 +1,98 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.ecs.model.TaskDefinition;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+import hudson.model.Node;
+
+
+public class ProvisioningCallbackTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void callbackCall_existingTemplate_runsEcsTask() throws Exception {
+
+        ECSTaskTemplate template = new ECSTaskTemplate(
+            "templateName", "template-label",
+            null, "image", "EC2", "remoteFSRoot",
+            0, 0, 0, null, null, false, false,
+            "containerUser", null, null, null, null, null);
+
+        List<ECSTaskTemplate> templates = new ArrayList<ECSTaskTemplate>();
+        ECSCloud cloud = new ECSCloud("testcloud", templates, "", "cluster", "regionName", "jenkinsUrl", 0);
+        TaskDefinition taskDefinition = new TaskDefinition().withFamily("myfamily");
+
+        ECSService ecs = Mockito.mock(ECSService.class);
+        Mockito.when(ecs.registerTemplate(cloud, template)).thenReturn(taskDefinition);
+        Mockito.when(ecs.runEcsTask(any(ECSSlave.class), template, anyString(), anyCollection(), taskDefinition)).thenReturn("arn::aws::region::task");
+
+        ProvisioningCallback callback = new ProvisioningCallback(cloud, ecs, template);
+        Node node = callback.call();
+
+        assertEquals("template-label", node.getLabelString());
+        assertEquals("arn::aws::region::task", ((ECSSlave)node).getTaskArn());
+        assertTrue(node.getNodeName().startsWith("testcloud-"));
+    }
+
+    @Test
+    public void callbackCall_existingTaskDefinitionOverride_runsEcsTask() throws Exception {
+
+        ECSTaskTemplate template = new ECSTaskTemplate(
+            "templateName", "template-label",
+            "arn::aws::region::taskdefinition", "image", "EC2", "remoteFSRoot",
+            0, 0, 0, null, null, false, false,
+            "containerUser", null, null, null, null, null);
+
+        List<ECSTaskTemplate> templates = new ArrayList<ECSTaskTemplate>();
+        ECSCloud cloud = new ECSCloud("testcloud", templates, "", "cluster", "regionName", "jenkinsUrl", 0);
+
+        ECSService ecs = mock(ECSService.class);
+        TaskDefinition taskDefinition = new TaskDefinition().withFamily("myfamily");
+        when(ecs.findTaskDefinition("arn::aws::region::taskdefinition")).thenReturn(taskDefinition);
+
+        ProvisioningCallback callback = new ProvisioningCallback(cloud, ecs, template);
+
+        Node node = callback.call();
+
+        assertThat(node, is(instanceOf(ECSSlave.class)));
+        assertEquals("template-label", node.getLabelString());
+        assertTrue(node.getNodeName().startsWith("testcloud-"));
+
+        // should run task
+        verify(ecs).runEcsTask(any(ECSSlave.class), template, anyString(), anyCollection(), any(TaskDefinition.class));
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void callbackCall_taskDefinitionDoesntExist_fails() throws Exception {
+
+        ECSTaskTemplate template = new ECSTaskTemplate(
+            "templateName", "template-label",
+            "arn::aws::region::taskdefinition", "image", "EC2", "remoteFSRoot",
+            0, 0, 0, null, null, false, false,
+            "containerUser", null, null, null, null, null);
+
+        List<ECSTaskTemplate> templates = new ArrayList<ECSTaskTemplate>();
+        ECSCloud cloud = new ECSCloud("testcloud", templates, "", "cluster", "regionName", "jenkinsUrl", 0);
+
+        ECSService ecs = mock(ECSService.class);
+        when(ecs.findTaskDefinition("arn::aws::region::taskdefinition")).thenReturn(null);
+
+        ProvisioningCallback callback = new ProvisioningCallback(cloud, ecs, template);
+        callback.call();
+    }
+}


### PR DESCRIPTION
## Goal
Allow agent configuration inside Jenkinsfile, supporting declarative pipelines.

Example use cases:
* "I want to have more memory for this specific build step"
* "My agent should run with a different IAM role"


## Status quo
Jenkins allows you to define clouds which are responsible to dynamically expand/shrink your agents. There are multiple implementations, like this one.

As part of the ECS cloud, multiple templates can defined which are the definitions for container-based agents running as ECS tasks. Inside the Jenkinsfile, the agent can be referenced by the label. When the label matches one of the templates, the ECS plugin creates or updates the task definition and starts an ECS task. 

## Changes
In addition, to the template configuration in Jenkins management configuration, users should be able to define the agent templates declaratively inside their Jenkinsfile. 

```groovy (declarative syntax)
pipeline {
    agent {
        ecsTask {
            label: myagent
            image: jankins/slave
            ...
        }
    }
    stages {
        stage('Stage 1') {
            steps {
                echo 'Hello world!' 
            }
        }
    }
}
```


In addition, these templates should be able to inherit from existing template definitions. This allows users to just overwrite the settings they want to have changed and don't define everything again and again.


__Important:__ 
This feature allows every user to define their own agent, which can have negative impacts regarding security. Before, admin access was needed to configure the templates.

## Terms:

`Cloud:` A Jenkins construct which dynamically expand/shrink agents
`Template:` The definition of an agent inside a specific cloud configuration.

Would love to get feedback on this!
