### PR TITLE
Added support for {MASTER_IP} placeholder in tunnel parameter

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -103,13 +103,14 @@ public class ECSCloud extends Cloud {
 
     private int slaveTimoutInSeconds;
 
-    private String insufficientResourcesCloudWatchAlarm;
+    private int insufficientResourcesSeconds;
+    private String insufficientResourcesAction;
 
     private ECSService ecsService;
 
     @DataBoundConstructor
     public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId,
-            String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds, String insufficientResourcesCloudWatchAlarm) throws InterruptedException{
+            String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds, int insufficientResourcesSeconds, String insufficientResourcesAction) throws InterruptedException{
         super(name);
         this.credentialsId = credentialsId;
         this.cluster = cluster;
@@ -129,7 +130,8 @@ public class ECSCloud extends Cloud {
             this.slaveTimoutInSeconds = DEFAULT_SLAVE_TIMEOUT;
         }
 
-        this.insufficientResourcesCloudWatchAlarm = insufficientResourcesCloudWatchAlarm;
+        this.insufficientResourcesSeconds = insufficientResourcesSeconds;
+        this.insufficientResourcesAction = insufficientResourcesAction;
     }
 
     synchronized ECSService getEcsService() {
@@ -229,12 +231,20 @@ public class ECSCloud extends Cloud {
         this.slaveTimoutInSeconds = slaveTimoutInSeconds;
     }
 
-    public String getInsufficientResourcesCloudWatchAlarm() {
-        return insufficientResourcesCloudWatchAlarm;
+    public int getInsufficientResourcesSeconds() {
+        return insufficientResourcesSeconds;
     }
 
-    public void setInsufficientResourcesCloudWatchAlarm(String insufficientResourcesCloudWatchAlarm) {
-        this.insufficientResourcesCloudWatchAlarm = insufficientResourcesCloudWatchAlarm;
+    public void setInsufficientResourcesSeconds(int actions) {
+        this.insufficientResourcesSeconds = insufficientResourcesSeconds;
+    }
+
+    public String getInsufficientResourcesAction() {
+        return insufficientResourcesAction;
+    }
+
+    public void setInsufficientResourcesAction(String actions) {
+        this.insufficientResourcesAction = insufficientResourcesAction;
     }
 
 
@@ -257,7 +267,7 @@ public class ECSCloud extends Cloud {
 
             synchronized (cluster) {
                 if (!template.isFargate()){
-                    getEcsService().waitForSufficientClusterResources(timeout, template, cluster, insufficientResourcesCloudWatchAlarm);
+                    getEcsService().waitForSufficientClusterResources(timeout, template, cluster, insufficientResourcesSeconds, insufficientResourcesAction);
                 }
 
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -103,11 +103,13 @@ public class ECSCloud extends Cloud {
 
     private int slaveTimoutInSeconds;
 
+    private boolean exceedingClusterResourcesAllowed;
+
     private ECSService ecsService;
 
     @DataBoundConstructor
     public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId,
-            String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds) throws InterruptedException{
+            String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds, boolean exceedingClusterResourcesAllowed) throws InterruptedException{
         super(name);
         this.credentialsId = credentialsId;
         this.cluster = cluster;
@@ -126,6 +128,8 @@ public class ECSCloud extends Cloud {
         } else {
             this.slaveTimoutInSeconds = DEFAULT_SLAVE_TIMEOUT;
         }
+
+        this.exceedingClusterResourcesAllowed = exceedingClusterResourcesAllowed;
     }
 
     synchronized ECSService getEcsService() {
@@ -225,6 +229,14 @@ public class ECSCloud extends Cloud {
         this.slaveTimoutInSeconds = slaveTimoutInSeconds;
     }
 
+    public boolean getExceedingClusterResourcesAllowed() {
+        return exceedingClusterResourcesAllowed;
+    }
+
+    public void setExceedingClusterResourcesAllowed(boolean exceedingClusterResourcesAllowed) {
+        this.exceedingClusterResourcesAllowed = exceedingClusterResourcesAllowed;
+    }
+
 
     private class ProvisioningCallback implements Callable<Node> {
 
@@ -244,7 +256,7 @@ public class ECSCloud extends Cloud {
             Date timeout = new Date(now.getTime() + 1000 * slaveTimoutInSeconds);
 
             synchronized (cluster) {
-                if (!template.isFargate()){
+                if (!exceedingClusterResourcesAllowed && !template.isFargate()){
                     getEcsService().waitForSufficientClusterResources(timeout, template, cluster);
                 }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -103,13 +103,13 @@ public class ECSCloud extends Cloud {
 
     private int slaveTimoutInSeconds;
 
-    private boolean exceedingClusterResourcesAllowed;
+    private String insufficientResourcesCloudWatchAlarm;
 
     private ECSService ecsService;
 
     @DataBoundConstructor
     public ECSCloud(String name, List<ECSTaskTemplate> templates, @Nonnull String credentialsId,
-            String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds, boolean exceedingClusterResourcesAllowed) throws InterruptedException{
+            String cluster, String regionName, String jenkinsUrl, int slaveTimoutInSeconds, String insufficientResourcesCloudWatchAlarm) throws InterruptedException{
         super(name);
         this.credentialsId = credentialsId;
         this.cluster = cluster;
@@ -129,7 +129,7 @@ public class ECSCloud extends Cloud {
             this.slaveTimoutInSeconds = DEFAULT_SLAVE_TIMEOUT;
         }
 
-        this.exceedingClusterResourcesAllowed = exceedingClusterResourcesAllowed;
+        this.insufficientResourcesCloudWatchAlarm = insufficientResourcesCloudWatchAlarm;
     }
 
     synchronized ECSService getEcsService() {
@@ -229,12 +229,12 @@ public class ECSCloud extends Cloud {
         this.slaveTimoutInSeconds = slaveTimoutInSeconds;
     }
 
-    public boolean getExceedingClusterResourcesAllowed() {
-        return exceedingClusterResourcesAllowed;
+    public String getInsufficientResourcesCloudWatchAlarm() {
+        return insufficientResourcesCloudWatchAlarm;
     }
 
-    public void setExceedingClusterResourcesAllowed(boolean exceedingClusterResourcesAllowed) {
-        this.exceedingClusterResourcesAllowed = exceedingClusterResourcesAllowed;
+    public void setInsufficientResourcesCloudWatchAlarm(String insufficientResourcesCloudWatchAlarm) {
+        this.insufficientResourcesCloudWatchAlarm = insufficientResourcesCloudWatchAlarm;
     }
 
 
@@ -256,8 +256,8 @@ public class ECSCloud extends Cloud {
             Date timeout = new Date(now.getTime() + 1000 * slaveTimoutInSeconds);
 
             synchronized (cluster) {
-                if (!exceedingClusterResourcesAllowed && !template.isFargate()){
-                    getEcsService().waitForSufficientClusterResources(timeout, template, cluster);
+                if (!template.isFargate()){
+                    getEcsService().waitForSufficientClusterResources(timeout, template, cluster, insufficientResourcesCloudWatchAlarm);
                 }
 
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -313,13 +315,26 @@ public class ECSCloud extends Cloud {
         }
     }
 
+    private String expandTunnelString(String tunnel) {
+        if(tunnel.contains("{MASTER_IP}")) {
+
+            try {
+                tunnel = tunnel.replace("{MASTER_IP}", InetAddress.getLocalHost().getHostAddress() );
+            }
+            catch(UnknownHostException e) {
+                LOGGER.log(Level.WARNING, "Failed to resolve address of master host for tunnel.", e);
+            }
+        }
+        return tunnel;
+    }
+
     private Collection<String> getDockerRunCommand(ECSSlave slave) {
         Collection<String> command = new ArrayList<String>();
         command.add("-url");
         command.add(jenkinsUrl);
         if (StringUtils.isNotBlank(tunnel)) {
             command.add("-tunnel");
-            command.add(tunnel);
+            command.add( expandTunnelString(tunnel) );
         }
         command.add(slave.getComputer().getJnlpMac());
         command.add(slave.getComputer().getName());

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -384,7 +384,7 @@ class ECSService {
             value = "";
         }
 
-        if(type=="CloudWatchAlarm") {
+        if(type.equals("CloudWatchAlarm") ) {
             try {
                 SetAlarmStateRequest alarmRequest = new SetAlarmStateRequest();
                 alarmRequest.setAlarmName(value);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.List;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
@@ -69,6 +70,9 @@ import com.amazonaws.services.ecs.model.RunTaskRequest;
 import com.amazonaws.services.ecs.model.RunTaskResult;
 import com.amazonaws.services.ecs.model.StopTaskRequest;
 import com.amazonaws.services.ecs.model.TaskOverride;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.model.SetAlarmStateRequest;
+import com.amazonaws.services.cloudwatch.model.StateValue;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -130,6 +134,30 @@ class ECSService {
         }
         client.setRegion(getRegion(regionName));
         LOGGER.log(Level.FINE, "Selected Region: {0}", regionName);
+        return client;
+    }
+
+    AmazonCloudWatchClient getAmazonCloudWatchClient() {
+        final AmazonCloudWatchClient client;
+
+        ProxyConfiguration proxy = Jenkins.getInstance().proxy;
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        if(proxy != null) {
+            clientConfiguration.setProxyHost(proxy.name);
+            clientConfiguration.setProxyPort(proxy.port);
+            clientConfiguration.setProxyUsername(proxy.getUserName());
+            clientConfiguration.setProxyPassword(proxy.getPassword());
+        }
+
+        AmazonWebServicesCredentials credentials = getCredentials(credentialsId);
+        if (credentials == null) {
+            // no credentials provided, rely on com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+            // to use IAM Role define at the EC2 instance level ...
+            client = new AmazonCloudWatchClient(clientConfiguration);
+        } else {
+            client = new AmazonCloudWatchClient(credentials, clientConfiguration);
+        }
+        client.setRegion(getRegion(regionName));
         return client;
     }
 
@@ -343,34 +371,64 @@ class ECSService {
     }
 
     void waitForSufficientClusterResources(Date timeout, ECSTaskTemplate template, String clusterArn) throws InterruptedException, AbortException {
+        waitForSufficientClusterResources(timeout, template, clusterArn, "");
+    }
+
+    void waitForSufficientClusterResources(Date timeout, ECSTaskTemplate template, String clusterArn, String insufficientResourcesCloudWatchAlarm) throws InterruptedException, AbortException {
         AmazonECSClient client = getAmazonECSClient();
 
         boolean hasEnoughResources = false;
+        boolean didSignalAlarm = false;
         WHILE:
         do {
             ListContainerInstancesResult listContainerInstances = client.listContainerInstances(new ListContainerInstancesRequest().withCluster(clusterArn));
-            DescribeContainerInstancesResult containerInstancesDesc = client.describeContainerInstances(new DescribeContainerInstancesRequest().withContainerInstances(listContainerInstances.getContainerInstanceArns()).withCluster(clusterArn));
-            LOGGER.log(Level.INFO, "Found {0} instances", containerInstancesDesc.getContainerInstances().size());
-            for(ContainerInstance instance : containerInstancesDesc.getContainerInstances()) {
-                LOGGER.log(Level.INFO, "Resources found in instance {1}: {0}", new Object[] {instance.getRemainingResources(), instance.getContainerInstanceArn()});
-                Resource memoryResource = null;
-                Resource cpuResource = null;
-                for(Resource resource : instance.getRemainingResources()) {
-                    if("MEMORY".equals(resource.getName())) {
-                        memoryResource = resource;
-                    } else if("CPU".equals(resource.getName())) {
-                        cpuResource = resource;
+            List<String> instanceArns = listContainerInstances.getContainerInstanceArns();
+            if(instanceArns.isEmpty()) {
+                LOGGER.log(Level.INFO, "Found no instances.");
+            } else {
+                DescribeContainerInstancesResult containerInstancesDesc = client.describeContainerInstances(new DescribeContainerInstancesRequest().withContainerInstances(instanceArns).withCluster(clusterArn));
+                LOGGER.log(Level.INFO, "Found {0} instances", containerInstancesDesc.getContainerInstances().size());
+                for(ContainerInstance instance : containerInstancesDesc.getContainerInstances()) {
+                    LOGGER.log(Level.INFO, "Resources found in instance {1}: {0}", new Object[] {instance.getRemainingResources(), instance.getContainerInstanceArn()});
+                    Resource memoryResource = null;
+                    Resource cpuResource = null;
+                    for(Resource resource : instance.getRemainingResources()) {
+                        if("MEMORY".equals(resource.getName())) {
+                            memoryResource = resource;
+                        } else if("CPU".equals(resource.getName())) {
+                            cpuResource = resource;
+                        }
+                    }
+
+                    LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemoryConstraint()});
+                    LOGGER.log(Level.INFO, "Instance {0} has {1} units of free cpu. {2} units are required", new Object[]{ instance.getContainerInstanceArn(), cpuResource.getIntegerValue(), template.getCpu()});
+                    if(memoryResource.getIntegerValue() >= template.getMemoryConstraint()
+                            && cpuResource.getIntegerValue() >= template.getCpu()) {
+                        hasEnoughResources = true;
+                        break WHILE;
                     }
                 }
+            }
 
-                LOGGER.log(Level.INFO, "Instance {0} has {1}mb of free memory. {2}mb are required", new Object[]{ instance.getContainerInstanceArn(), memoryResource.getIntegerValue(), template.getMemoryConstraint()});
-                LOGGER.log(Level.INFO, "Instance {0} has {1} units of free cpu. {2} units are required", new Object[]{ instance.getContainerInstanceArn(), cpuResource.getIntegerValue(), template.getCpu()});
-                if(memoryResource.getIntegerValue() >= template.getMemoryConstraint()
-                        && cpuResource.getIntegerValue() >= template.getCpu()) {
-                    hasEnoughResources = true;
-                    break WHILE;
+            if( StringUtils.isNotEmpty(insufficientResourcesCloudWatchAlarm) && !didSignalAlarm) {
+
+                LOGGER.log(Level.INFO, "ECS cluster has insufficient resources. Signalling CloudWatch alarm: "+insufficientResourcesCloudWatchAlarm);
+
+                try {
+                    SetAlarmStateRequest alarmRequest = new SetAlarmStateRequest();
+                    alarmRequest.setAlarmName(insufficientResourcesCloudWatchAlarm);
+                    alarmRequest.setStateReason("Jenkins master detected insufficient cluster resources.");
+                    alarmRequest.setStateValue(StateValue.ALARM);
+
+                    getAmazonCloudWatchClient().setAlarmState( alarmRequest );        
+
+                    didSignalAlarm = true;
+                }
+                catch(Exception e) {
+                    LOGGER.log(Level.SEVERE, "Couldn't signal CloudWatch alarm " + insufficientResourcesCloudWatchAlarm + ": " + e.getMessage(), e);                    
                 }
             }
+
 
             // sleep 10s and check memory again
             Thread.sleep(10000);

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -51,8 +51,8 @@
     <f:entry field="slaveTimoutInSeconds" title="${%ECS task creation timeout}" description="Timeout (in second) for ECS task to be created, usefull if you use large docker slave image, because the host will take more time to pull the docker image">
       <f:textbox />
     </f:entry>
-    <f:entry field="exceedingClusterResourcesAllowed" title="${%Exceeding cluster resources is allowed}" description="If enabled then Jenkins will not wait until the cluster has sufficient free resources before scheduling new tasks. It is recommended to enable this if your cluster auto scales based on CPU or memory reservation. Has no effect for Fargate tasks.">
-      <f:checkbox />
+    <f:entry field="insufficientResourcesCloudWatchAlarm" title="${%CloudWatch alarm for insufficient ECS cluster resources}" description="Name of a CloudWatch alarm to signal when the ECS cluster does not have enough free resources to handle all scheduled tasks. This is never signalled for ECS clusters of the Fargate type.">
+      <f:textbox />
     </f:entry>
   </f:advanced>
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -51,9 +51,14 @@
     <f:entry field="slaveTimoutInSeconds" title="${%ECS task creation timeout}" description="Timeout (in second) for ECS task to be created, usefull if you use large docker slave image, because the host will take more time to pull the docker image">
       <f:textbox />
     </f:entry>
-    <f:entry field="insufficientResourcesCloudWatchAlarm" title="${%CloudWatch alarm for insufficient ECS cluster resources}" description="Name of a CloudWatch alarm to signal when the ECS cluster does not have enough free resources to handle all scheduled tasks. This is never signalled for ECS clusters of the Fargate type.">
+    <f:entry field="insufficientResourcesSeconds" title="${%When insufficient resources for seconds}" description="When there are not enough resources in the ECS cluster to handle a build then Jenkins waits for this number of seconds before it triggers the action indicated below. This has no effect for clusters with the Fargate launch type.">
       <f:textbox />
     </f:entry>
+    <f:entry field="insufficientResourcesAction" title="${%then do this action}" description="Describes an action to perform when Jenkins has been waiting for sufficient ECS cluster resources for the amount of time specified above. Right now the action can only be 'CloudWatchAlarm:ALARMNAME' (which triggers the CloudWatch alarm with the specified name).">
+      <f:textbox />
+    </f:entry>
+    
+    
   </f:advanced>
 
   <f:entry title="${%ECS slave templates}">

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -51,6 +51,9 @@
     <f:entry field="slaveTimoutInSeconds" title="${%ECS task creation timeout}" description="Timeout (in second) for ECS task to be created, usefull if you use large docker slave image, because the host will take more time to pull the docker image">
       <f:textbox />
     </f:entry>
+    <f:entry field="exceedingClusterResourcesAllowed" title="${%Exceeding cluster resources is allowed}" description="If enabled then Jenkins will not wait until the cluster has sufficient free resources before scheduling new tasks. It is recommended to enable this if your cluster auto scales based on CPU or memory reservation. Has no effect for Fargate tasks.">
+      <f:checkbox />
+    </f:entry>
   </f:advanced>
 
   <f:entry title="${%ECS slave templates}">


### PR DESCRIPTION
We have added support for a placeholder {MASTER_IP} in the tunnel parameter. This placeholder is replaced with the IP address of the Jenkins master at runtime.

One example for a case where this parameter is needed:

- Jenkins is behind a load balancer (open to the public internet)
- Jenkins is run on dynamically created cloud servers (dynamic/unknown IP, no DNS entry for the Jenkins host)
- One does not want to run the slave connections through the load balancer (for example because they should not be open to the public internet).

We had such a setup in our organization. The old tunnel parameter is not quite sufficient to solve this, because the Jenkins IP address and host name are chosen dynamically (so they are unknown at the time the settings are created).

With the place holder the master's IP address is inserted at runtime and the slaves can connect directly to the master, bypassing the load balancer.
