### PR TITLE
Added support for {MASTER_IP} placeholder in tunnel parameter

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -313,13 +315,26 @@ public class ECSCloud extends Cloud {
         }
     }
 
+    private String expandTunnelString(String tunnel) {
+        if(tunnel.contains("{MASTER_IP}")) {
+
+            try {
+                tunnel = tunnel.replace("{MASTER_IP}", InetAddress.getLocalHost().getHostAddress() );
+            }
+            catch(UnknownHostException e) {
+                LOGGER.log(Level.WARNING, "Failed to resolve address of master host for tunnel.", e);
+            }
+        }
+        return tunnel;
+    }
+
     private Collection<String> getDockerRunCommand(ECSSlave slave) {
         Collection<String> command = new ArrayList<String>();
         command.add("-url");
         command.add(jenkinsUrl);
         if (StringUtils.isNotBlank(tunnel)) {
             command.add("-tunnel");
-            command.add(tunnel);
+            command.add( expandTunnelString(tunnel) );
         }
         command.add(slave.getComputer().getJnlpMac());
         command.add(slave.getComputer().getName());


### PR DESCRIPTION
This pull request replaces PR-67, which was inadvertently created from the wrong source branch.

We have added support for a placeholder {MASTER_IP} in the tunnel parameter. This placeholder is replaced with the IP address of the Jenkins master at runtime.

One example for a case where this parameter is needed:

Jenkins is behind a load balancer (open to the public internet)
Jenkins is run on dynamically created cloud servers (dynamic/unknown IP, no DNS entry for the Jenkins host)
One does not want to run the slave connections through the load balancer (for example because they should not be open to the public internet).
We had such a setup in our organization. The old tunnel parameter is not quite sufficient to solve this, because the Jenkins IP address and host name are chosen dynamically (so they are unknown at the time the settings are created).

With the place holder the master's IP address is inserted at runtime and the slaves can connect directly to the master, bypassing the load balancer.