### PR TITLE
Add configure page for agent

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave/configure-entries.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave/configure-entries.jelly
@@ -1,0 +1,26 @@
+<!--
+  Config page
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Description}" help="/help/system-config/master-slave/description.html">
+    <f:textbox field="nodeDescription" />
+  </f:entry>
+
+  <f:entry title="${%Task Definition Arn}" field="TaskDefinitonArn">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Task Arn}" field="TaskArn">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Labels}" field="labelString">
+    <f:textbox />
+  </f:entry>
+
+  <f:slave-mode name="mode" node="${it}" />
+
+  <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
+</j:jelly>


### PR DESCRIPTION
When you click on Agent -> Configure, a 5xx error page is shown. This PR adds the missing jelly page.