### PR TITLE
Add Pipeline Support for Creating ECS Task Templates

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep.java
@@ -1,0 +1,229 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import com.amazonaws.services.ecs.model.*;
+
+import hudson.Extension;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.steps.*;
+
+import com.google.inject.Inject;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
+public class ECSTaskTemplateStep extends AbstractStepImpl {
+    private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
+
+    private ECSTaskTemplate template;
+    private ECSCloud cloud;
+    private String cloudName;
+
+    @DataBoundConstructor
+    public ECSTaskTemplateStep(
+        @Nonnull String cloudName,
+        @Nonnull String templateName,
+        @Nullable String label,
+        @Nullable String taskDefinitionOverride,
+        @Nonnull String image,
+        @Nonnull String launchType,
+        @Nonnull String networkMode,
+        @Nullable String remoteFSRoot,
+        int memory,
+        int memoryReservation,
+        int cpu,
+        @Nullable String subnets,
+        @Nullable String securityGroups,
+        boolean assignPublicIp,
+        boolean privileged,
+        @Nullable String containerUser,
+        @Nullable List<ECSTaskTemplate.LogDriverOption> logDriverOptions,
+        @Nullable List<ECSTaskTemplate.EnvironmentEntry> environments,
+        @Nullable List<ECSTaskTemplate.ExtraHostEntry> extraHosts,
+        @Nullable List<ECSTaskTemplate.MountPointEntry> mountPoints,
+        @Nullable List<ECSTaskTemplate.PortMappingEntry> portMappings) {
+            this.cloudName = cloudName;
+            try {
+                this.cloud = (ECSCloud) Jenkins.get().clouds.getByName(cloudName);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Cannot create template for cloud {0}", cloudName);
+                LOGGER.log(Level.WARNING, "Cloud {0} is not configured", cloudName);
+            }
+            this.template = new ECSTaskTemplate(
+                templateName,
+                label,
+                taskDefinitionOverride,
+                image,
+                launchType,
+                networkMode,
+                remoteFSRoot,
+                memory,
+                memoryReservation,
+                cpu,
+                subnets,
+                securityGroups,
+                assignPublicIp,
+                privileged,
+                containerUser,
+                logDriverOptions,
+                environments,
+                extraHosts,
+                mountPoints,
+                portMappings);        
+    }
+
+    public String getCloudName() {
+        return cloudName;
+    }
+
+    public ECSCloud getCloud() {
+        return cloud;
+    }
+
+    public ECSTaskTemplate getTemplate() {
+        return template;
+    }
+
+    public String getTemplateName() {
+        return template.getTemplateName();
+    }
+
+    public String getLabel() {
+        return template.getLabel();
+    }
+
+    public String getTaskDefinitionOverride() {
+        return template.getTaskDefinitionOverride();
+    }
+
+    public String getImage() {
+        return template.getImage();
+    }
+
+    public String getLaunchType() {
+        return template.getLaunchType();
+    }
+
+    public String getNetworkMode() {
+        return template.getNetworkMode();
+    }
+
+    public String getRemoteFSRoot() {
+        return template.getRemoteFSRoot();
+    }
+
+    public int getMemory() {
+        return template.getMemory();
+    }
+
+    public int getMemoryReservation() {
+        return template.getMemoryReservation();
+    }
+
+    public int getCpu() {
+        return template.getCpu();
+    }
+
+    public String getSubnets() {
+        return template.getSubnets();
+    }
+
+    public String getSecurityGroups() {
+        return template.getSecurityGroups();
+    }
+
+    public boolean getAssignPublicIp() {
+        return template.getAssignPublicIp();
+    }
+
+    public boolean getPrivileged() {
+        return template.getPrivileged();
+    }
+
+    public String getContainerUser() {
+        return template.getContainerUser();
+    }
+
+    public List<ECSTaskTemplate.LogDriverOption> getLogDriverOptions() {
+        return template.getLogDriverOptions();
+    }
+
+    public List<ECSTaskTemplate.EnvironmentEntry> getEnvironments() {
+        return template.getEnvironments();
+    }
+
+    public List<ECSTaskTemplate.ExtraHostEntry> getExtraHosts() {
+        return template.getExtraHosts();
+    }
+
+    public List<ECSTaskTemplate.MountPointEntry> getMountPoints() {
+        return template.getMountPoints();
+    }
+
+    public List<ECSTaskTemplate.PortMappingEntry> getPortMappings() {
+        return template.getPortMappings();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        @Override
+        public String getFunctionName() {
+            return "ecsCreateTaskTemplate";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "ECS Task Template Provisioning";
+        }
+
+        public DescriptorImpl() {
+            super(ECSTaskTemplateExecution.class);
+        }
+
+        public ListBoxModel doFillLaunchTypeItems() {
+            final ListBoxModel options = new ListBoxModel();
+            for (LaunchType launchType : LaunchType.values()) {
+                options.add(launchType.toString());
+            }
+            return options;
+        }
+
+        public ListBoxModel doFillNetworkModeItems() {
+            final ListBoxModel options = new ListBoxModel();
+            for (NetworkMode networkMode : NetworkMode.values()) {
+                options.add(networkMode.toString());
+            }
+            return options;
+        }
+
+        public ListBoxModel doFillProtocolItems() {
+            final ListBoxModel options = new ListBoxModel();
+            options.add("TCP", "tcp");
+            options.add("UDP", "udp");
+            return options;
+        }
+
+    }
+
+    private static class ECSTaskTemplateExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+        @Inject
+        private transient ECSTaskTemplateStep step;
+
+        @Override
+        protected Void run() throws Exception {
+            if (step.cloud != null) {
+                step.cloud.getTemplates().add(step.template);
+                Jenkins.get().save();
+            }
+            return null;
+        }
+
+    }
+}

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/PortMappingEntry/help-containerPort.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/PortMappingEntry/help-containerPort.html
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+The port number on the container to bind to the host port.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/PortMappingEntry/help-hostPort.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/PortMappingEntry/help-hostPort.html
@@ -1,0 +1,28 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+<p>The port number on the host instance to map to the container port.</p>
+<p>If no host port is provided (or it is set to 0), the container will receive a port in the ephemeral port range.</p>
+<p>Reserved ports: 22 (SSH), 2375-2376 (Docker), and 51678 (ECS container agent)</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/PortMappingEntry/help-protocol.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/PortMappingEntry/help-protocol.html
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+The protocol used for the port mapping.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/config.jelly
@@ -1,0 +1,190 @@
+<?jelly escape-by-default='true'?>
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Cloud Name}" field="cloudName" description="The ECS cloud">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="Label" field="label" description="The label used to identify this slave in Jenkins.">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="${%Template Name}" field="templateName" description="The name that will be appended to the ECS cluster name when creating task definitions. Cannot be used with a Task Definition Override.">
+      <f:textbox />
+    </f:entry>
+  <f:entry title="${%Task Definition Override}" field="taskDefinitionOverride" description="Externally-managed ECS task definition to use, instead of creating task definitions using the Template Name. This value takes precedence over all other container settings.">
+      <f:textbox />
+  </f:entry>
+  <f:entry title="${%Docker Image}" field="image">
+    <f:textbox default="jenkinsci/jnlp-slave" />
+  </f:entry>
+  <f:entry name="launchType" title="${%Launch type}" field="launchType">
+    <f:select />
+  </f:entry>
+  <f:entry name="networkMode" title="${%Network mode}" field="networkMode">
+    <f:select />
+  </f:entry>
+  <f:entry title="${%Filesystem root}" field="remoteFSRoot">
+    <f:textbox default="/home/jenkins" />
+  </f:entry>
+  <f:entry title="${%Soft Memory Reservation (Mb)}" field="memoryReservation" description="The soft memory limit in Mb for the container. A 0 value implies no limit will be assigned. If in doubt apply a limit here and leave the Hard Memory Reservation to 0.">
+    <f:textbox default="0"/>
+  </f:entry>
+  <f:entry title="${%Hard Memory Reservation (Mb)}" field="memory" description="The hard memory limit in Mb for the container. A 0 value implies no limit will be assigned">
+    <f:textbox default="0"/>
+  </f:entry>
+  <f:entry title="${%CPU units}" field="cpu">
+    <f:textbox default="1"/>
+  </f:entry>
+  <f:entry title="${%Subnets}" field="subnets" description="List of subnets, separated by comma, only needed when using fargate or awsvpc network mode">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="${%Security Groups}" field="securityGroups" description="List of security groups, separated by comma, only needed when using fargate or awsvpc network mode">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="${%Assign Public Ip}" field="assignPublicIp" description="Assign public IP, only needed when using fargate or awsvpc network mode">
+    <f:checkbox />
+  </f:entry>
+  <f:advanced>
+    <f:entry title="${%DNS Search Domains}" field="dnsSearchDomains">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Task Role ARN}" field="taskrole">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Task Execution Role ARN}" field="executionRole">
+      <f:textbox default="ecsTaskExecutionRole"/>
+    </f:entry>
+    <f:entry title="${%Override entrypoint}" field="entrypoint">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%JVM arguments}" field="jvmArgs">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Privileged}" field="privileged">
+      <f:checkbox />
+    </f:entry>
+    <f:entry title="${%ContainerUser}" field="containerUser">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Logging Driver}" field="logDriver">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Logging Configuration}">
+      <f:repeatable field="logDriverOptions">
+        <table width="100%">
+          <f:entry title="${%Name}" field="name">
+            <f:textbox />
+          </f:entry>
+          <f:entry title="${%Value}" field="value">
+            <f:textbox />
+          </f:entry>
+          <f:entry>
+            <div align="right">
+              <f:repeatableDeleteButton />
+            </div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+    <f:entry title="${%Environments}">
+      <f:repeatable field="environments">
+        <table width="100%">
+          <f:entry title="${%Name}" field="name">
+            <f:textbox />
+          </f:entry>
+          <f:entry title="${%Value}" field="value">
+            <f:textbox />
+          </f:entry>
+          <f:entry>
+            <div align="right">
+              <f:repeatableDeleteButton />
+            </div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+    <f:entry title="${%Extra Hosts}">
+      <f:repeatable field="extraHosts">
+        <table width="100%">
+          <f:entry title="${%IP Address}" field="ipAddress">
+            <f:textbox value="${instance.ipAddress}" />
+          </f:entry>
+          <f:entry title="${%Hostname}" field="hostname">
+            <f:textbox value="${instance.hostname}" />
+          </f:entry>
+          <f:entry>
+            <div align="right">
+              <f:repeatableDeleteButton />
+            </div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+    <f:entry title="${%Container Mount Points}">
+      <f:repeatable field="mountPoints">
+        <table width="100%">
+          <f:entry title="${%Name}" field="name">
+            <f:textbox value="${instance.name}" />
+          </f:entry>
+          <f:entry title="${%Source Path}" field="sourcePath">
+            <f:textbox value="${instance.sourcePath}" />
+          </f:entry>
+          <f:entry title="${%Container Path}" field="containerPath">
+            <f:textbox value="${instance.containerPath}" />
+          </f:entry>
+          <f:entry title="${%Read Only}" field="readOnly">
+            <f:checkbox />
+          </f:entry>
+          <f:entry title="">
+            <div align="right">
+              <f:repeatableDeleteButton />
+            </div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+    <f:entry field="portMappings" title="${%Port Mappings}">
+      <f:repeatable field="portMappings">
+        <table width="100%">
+          <f:entry field="containerPort" title="${%Container Port}">
+            <f:textbox />
+          </f:entry>
+          <f:entry field="hostPort" title="${%Host Port}">
+            <f:textbox />
+          </f:entry>
+          <f:entry field="protocol" title="${%Protocol}">
+            <f:select />
+          </f:entry>
+          <f:entry>
+            <div align="right">
+              <f:repeatableDeleteButton />
+            </div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+  </f:advanced>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-cpu.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-cpu.html
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+The number of cpu units to reserve for the container. A container instance has 1,024 cpu units for every CPU core.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-dnsSearchDomains.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-dnsSearchDomains.html
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+A list of DNS search domains that are presented to the container.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-entrypoint.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-entrypoint.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+You can rely on this option to overwrite the Docker image entrypoint. Container command can't be overriden as it
+is used to pass jenkins slave connection parameters. White list separated

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-executionRole.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-executionRole.html
@@ -1,0 +1,36 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+<p>
+    The Amazon ECS container agent makes calls to the Amazon ECS API actions on your behalf,
+    so it requires an IAM policy and role for the service to know that the agent belongs to you
+</p>
+<p>
+    Only relevant for FARGATE. If not specified, the plugin will try to use the default <b>ecsTaskExecutionRole</b> role
+</p>
+<p>
+    See <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html">ECS Task Execution IAM Role</a> for
+    more details about task execution roles.
+</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-externalTaskDefinition.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-externalTaskDefinition.html
@@ -1,0 +1,48 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+<p>
+    Use an externally-managed task definition, rather than one created by Jenkins. Allows you to use a task definition
+    created in the AWS Console, command line, or other tools. Specifying an explicit task definition will override all
+    other task definition options, and will prevent Jenkins from creating or modifying task definitions for this slave.
+    (You should still specify reasonable CPU and memory sizes in Jenkins. The values will not be used by ECS, but will be
+    used by Jenkins to estimate cluster capacity.)
+</p>
+<p>
+    You may specify either a full task definition ARN, a family name, or a family name and revision. If specifying only a
+    family name, Jenkins will use the latest active task definition with that family name. If you enter the full ARN, Jenkins will
+    always use the specified ARN, even if you create later revisions of the task definition. See the
+    <a href="http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTaskDefinition.html">DescribeTaskDefinition API documentation</a>
+    for details.
+</p>
+<p>
+    For example, if the task definition you would like to use is in the "hello_world" family, you could enter
+    "hello_world", "hello_world:8", or "arn:aws:ecs:us-east-1:123456789012:task-definition/hello_world:8" as the Task
+    Definition Override.
+</p>
+<p>
+    <b>Important:</b> If your externally-managed task definition contains multiple container definitions (sidecars), the
+    Jenkins slave container must be the first container defined in the task definition.
+</p>
+

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-image.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-image.html
@@ -1,0 +1,32 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+Docker image to run as a jenkins slave agent.
+<p>
+This image will be ran passing command "<code>-url [jenkins url] [slave jnlp secret] [slave name]</code>". Those are
+the parameters expected by
+<a href="https://github.com/jenkinsci/remoting/blob/master/src/main/java/hudson/remoting/jnlp/Main.java">Jenkins remoting JNLP launcher</a>.
+You can use or inherit from  <a href="https://hub.docker.com/r/jenkinsci/jnlp-slave/">jenkinsci/jnlp-slave</a>
+Docker image so you dont' have to wory about those implementation details.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-memory.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-memory.html
@@ -1,0 +1,25 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+The hard limit (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed. Either one of memory or memoryReservation must be set with 0 being "don't apply a limit"

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-memoryReservation.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-memoryReservation.html
@@ -1,0 +1,25 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first. Either one of memory or memoryReservation must be set with 0 being "don't apply a limit"

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-networkMode.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-networkMode.html
@@ -1,0 +1,30 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+The network mode to apply to the task. See <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#network_mode" target="_blank">Network Mode</a> for more details.</br>
+</br>
+If using <b>awsvpc</b>, you must specify <b>Subnets</b> and can optionally specify <b>Security Groups</b> and <b>Assign Public IP</b>.<br>
+<br>
+Using the <b>none</b> mode will result in your slave having no network connectivity.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-portMappings.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-portMappings.html
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+Port mappings allow the task containers to access ports on the host instance.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-taskrole.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-taskrole.html
@@ -1,0 +1,41 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+<p>
+    AWS IAM Role to associate with the ECS Slave Task to grant permissions to access other AWS resources.
+</p>
+<p>
+    If your slave needs access to other AWS resources, you can create a role with appropriate policies and associate
+    that role with the slave ECS Task.
+</p>
+<p>
+    All containers within a task have access to all permissions defined in the instance profile of the container instances.
+    It is recommended to limit the permissions of container instances and specify service specific permissions at the
+    task level.
+</p>
+<p>
+    See <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html">Task IAM roles</a> for
+    more details about task roles.
+</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-templatename.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateStep/help-templatename.html
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+The name of the template. This will be used to create the task definition in ECS along with the cloud name.
+If no name is supplied a default name with a random uid will be used.


### PR DESCRIPTION
### Use Case:
A pipeline that:
* Dynamically builds Docker images based on parameters passed into the job
* Pushes that Docker image to a registry
* Needs to run the next step in the newly formed image

In order to run the step in a new Docker container in ECS, a user would need to be able to dynamically create an ECS task template and save it to an already configured ECS Cloud in the current Jenkins instance.

### Implementation:
**An AWS ECS Cloud must already be configured.** This Pipeline step simply finds the already configured cloud by the provided name, otherwise it fails to provision a task template. From there, it creates a template from the provided parameters and adds it to the cloud's templates.

There is some extra code overlap (e.g. form validations, extra getter methods) as this was all needed for the Pipeline syntax generator and I wasn't able to inherent from the original `DescriptorImpl` in the `ECSTaskTemplate` class as that inherits from a different type of `DescriptorImpl` than is needed for a Pipeline step.