### PR TITLE
Problems with EC2 as the launch type (not fargate). 

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -75,7 +75,7 @@
       <f:textbox />
     </f:entry>
     <f:entry title="${%Task Execution Role ARN}" field="executionRole">
-      <f:textbox default="ecsTaskExecutionRole"/>
+      <f:textbox />
     </f:entry>
     <f:entry title="${%Override entrypoint}" field="entrypoint">
       <f:textbox />

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-executionRole.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-executionRole.html
@@ -28,7 +28,7 @@
     so it requires an IAM policy and role for the service to know that the agent belongs to you
 </p>
 <p>
-    Only relevant for FARGATE. If not specified, the plugin will try to use the default <b>ecsTaskExecutionRole</b> role
+    Only relevant for FARGATE.
 </p>
 <p>
     See <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html">ECS Task Execution IAM Role</a> for


### PR DESCRIPTION
if an admin opens the jenkins system config, all the build slave configs will have the "Task Execution Role ARN" field reset back to their default value if this field was empty.