### PR TITLE
Unique paths for remote filesystem root

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+-   Feature - Optional unique paths for remote filesystem root
 
 ## 1.23
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -80,7 +80,7 @@ public class ECSSlave extends AbstractCloudSlave {
     private String taskArn;
 
     public ECSSlave(@Nonnull ECSCloud cloud, @Nonnull String name, ECSTaskTemplate template, @Nonnull ComputerLauncher launcher) throws Descriptor.FormException, IOException {
-        super(name, "ECS Agent", template.getRemoteFSRoot(), 1, Mode.EXCLUSIVE, template.getLabel(), launcher, new OnceRetentionStrategy(cloud.getRetentionTimeout()), Collections.emptyList());
+        super(name, "ECS Agent", template.makeRemoteFSRoot(name), 1, Mode.EXCLUSIVE, template.getLabel(), launcher, new OnceRetentionStrategy(cloud.getRetentionTimeout()), Collections.emptyList());
         this.cloud = cloud;
         this.template = template;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -227,6 +227,12 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     private final boolean privileged;
 
     /**
+     * Indicates whether to append a unique agent ID (the agent name)
+     * at the end of the remoteFSRoot path.
+     */
+    private final boolean uniqueRemoteFSRoot;
+
+    /**
      * User for conatiner
      */
     @Nullable
@@ -268,6 +274,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                            @Nonnull String launchType,
                            @Nonnull String networkMode,
                            @Nullable String remoteFSRoot,
+                           boolean uniqueRemoteFSRoot,
                            int memory,
                            int memoryReservation,
                            int cpu,
@@ -305,6 +312,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         this.image = image;
         this.repositoryCredentials = StringUtils.trimToNull(repositoryCredentials);
         this.remoteFSRoot = remoteFSRoot;
+        this.uniqueRemoteFSRoot = uniqueRemoteFSRoot;
         this.memory = memory;
         this.memoryReservation = memoryReservation;
         this.cpu = cpu;
@@ -396,6 +404,17 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
 
     public String getRemoteFSRoot() {
         return remoteFSRoot;
+    }
+
+    public String makeRemoteFSRoot(@Nonnull String name) {
+        if (!uniqueRemoteFSRoot || remoteFSRoot == null) {
+            return remoteFSRoot;
+        }
+        return remoteFSRoot + "/" + name;
+    }
+
+    public boolean getUniqueRemoteFSRoot() {
+        return uniqueRemoteFSRoot;
     }
 
     public int getMemory() {
@@ -550,6 +569,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         String launchType = Strings.isNullOrEmpty(this.launchType) ? parent.getLaunchType() : this.launchType;
         String networkMode = Strings.isNullOrEmpty(this.networkMode) ? parent.getNetworkMode() : this.networkMode;
         String remoteFSRoot = Strings.isNullOrEmpty(this.remoteFSRoot) ? parent.getRemoteFSRoot() : this.remoteFSRoot;
+        boolean uniqueRemoteFSRoot = this.uniqueRemoteFSRoot || parent.getUniqueRemoteFSRoot();
         int memory = this.memory == 0 ? parent.getMemory() : this.memory;
         int memoryReservation = this.memoryReservation == 0 ? parent.getMemoryReservation() : this.memoryReservation;
         int cpu = this.cpu == 0 ? parent.getCpu() : this.cpu;
@@ -580,6 +600,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                                                        launchType,
                                                        networkMode,
                                                        remoteFSRoot,
+                                                       uniqueRemoteFSRoot,
                                                        memory,
                                                        memoryReservation,
                                                        cpu,

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
@@ -31,6 +31,7 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
     private String image;
     private String launchType;
     private String remoteFSRoot;
+    private boolean uniqueRemoteFSRoot;
     private int memory;
     private int memoryReservation;
     private int cpu;
@@ -114,6 +115,16 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
     public void setRemoteFSRoot(String remoteFSRoot) {
         this.remoteFSRoot = remoteFSRoot;
         overrides.add("remoteFSRoot");
+    }
+
+    public boolean getUniqueRemoteFSRoot() {
+        return uniqueRemoteFSRoot;
+    }
+
+    @DataBoundSetter
+    public void setUniqueRemoteFSRoot(boolean uniqueRemoteFSRoot) {
+        this.uniqueRemoteFSRoot = uniqueRemoteFSRoot;
+        overrides.add("uniqueRemoteFSRoot");
     }
 
     public int getMemory() {
@@ -323,6 +334,7 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
         if (!StringUtils.isEmpty(remoteFSRoot)) {
             argMap.put("remoteFSRoot", remoteFSRoot);
         }
+        argMap.put("uniqueRemoteFSRoot", uniqueRemoteFSRoot);
 
         if (memory != 0) {
             argMap.put("memory", memory);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
@@ -47,6 +47,7 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
     private String launchType;
     private String networkMode;
     private String remoteFSRoot;
+    private boolean uniqueRemoteFSRoot;
     private int memory;
     private int memoryReservation;
     private int cpu;
@@ -145,6 +146,15 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
 
     public String getRemoteFSRoot() {
         return remoteFSRoot;
+    }
+
+    @DataBoundSetter
+    public void setUniqueRemoteFSRoot(boolean uniqueRemoteFSRoot) {
+        this.uniqueRemoteFSRoot = uniqueRemoteFSRoot;
+    }
+
+    public boolean getUniqueRemoteFSRoot() {
+        return uniqueRemoteFSRoot;
     }
 
     @DataBoundSetter
@@ -436,6 +446,7 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
                 "launchType='" + launchType + '\'' + '\n' +
                 "networkMode='" + networkMode + '\'' + '\n' +
                 "remoteFSRoot='" + remoteFSRoot + '\'' + '\n' +
+                "uniqueRemoteFSRoot='" + uniqueRemoteFSRoot + '\'' + '\n' +
                 "memory='" + memory + '\'' + '\n' +
                 "memoryReservation='" + memoryReservation + '\'' + '\n' +
                 "cpu='" + cpu + '\'' + '\n' +

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -81,6 +81,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
                                           step.getLaunchType(),
                                           step.getNetworkMode(),
                                           step.getRemoteFSRoot(),
+                                          step.getUniqueRemoteFSRoot(),
                                           step.getMemory(),
                                           step.getMemoryReservation(),
                                           step.getCpu(),

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -89,6 +89,9 @@
     <f:entry title="${%Privileged}" field="privileged">
       <f:checkbox />
     </f:entry>
+    <f:entry title="${%Unique filesystem root}" field="uniqueRemoteFSRoot">
+      <f:checkbox />
+    </f:entry>
     <f:entry title="${%ContainerUser}" field="containerUser">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-uniqueRemoteFSRoot.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-uniqueRemoteFSRoot.html
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+ 
+Append a unique agent ID (the agent name) at the end of the filesystem root path.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep/config.jelly
@@ -97,6 +97,9 @@
     <f:entry title="${%Privileged}" field="privileged">
       <f:checkbox />
     </f:entry>
+    <f:entry title="${%Unique filesystem root}" field="uniqueRemoteFSRoot">
+      <f:checkbox />
+    </f:entry>
     <f:entry title="${%ContainerUser}" field="containerUser">
       <f:textbox />
     </f:entry>

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -92,6 +92,7 @@ public class ECSCloudTest {
             "launchType",
             "networkMode",
             "remoteFSRoot",
+            false,
             0,
             0,
             0,

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -82,6 +82,7 @@ public class ECSSlaveTest {
             "launchType",
             "networkMode",
             "remoteFSRoot",
+            false,
             0,
             0,
             0,

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
@@ -12,19 +12,19 @@ public class ECSTaskTemplateTest {
         ECSTaskTemplate child = new ECSTaskTemplate(
             "child-name", "child-label",
             null, "child-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
-            0, 0, 0, null, null, false, false,
+            false, 0, 0, 0, null, null, false, false,
             "child-containerUser", null, null, null, null, null, null, null, null, "parent", 0);
 
         ECSTaskTemplate parent = new ECSTaskTemplate(
             "parent-name", "parent-label",
             null, "parent-image", "parent-repository-credentials", "FARGATE", "parent-network-mode", "parent-remoteFSRoot",
-            0, 0, 0, null, null, false, false,
+            false, 0, 0, 0, null, null, false, false,
             "parent-containerUser", null, null, null, null, null, null, null, null, null, 0);
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, "child-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
-            0, 0, 0, null, null, false, false,
+            false, 0, 0, 0, null, null, false, false,
             "child-containerUser", null, null, null, null, null, null, null, null, null, 0);
 
 
@@ -38,19 +38,19 @@ public class ECSTaskTemplateTest {
         ECSTaskTemplate child = new ECSTaskTemplate(
             "child-name", "child-label",
             null, null, "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot", // image is set to null
-            0, 0, 0, null, null, false, false,
+            false, 0, 0, 0, null, null, false, false,
             "child-containerUser", null, null, null, null, null, null, null, null, "parent", 0);
 
         ECSTaskTemplate parent = new ECSTaskTemplate(
             "parent-name", "parent-label",
             null, "parent-image", "parent-repository-credentials", "FARGATE", "parent-network-mode", "parent-remoteFSRoot",
-            0, 0, 0, null, null, false, false,
+            false, 0, 0, 0, null, null, false, false,
             "parent-containerUser", null, null, null, null, null, null, null, null, null, 0);
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, "parent-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
-            0, 0, 0, null, null, false, false,
+            false, 0, 0, 0, null, null, false, false,
             "child-containerUser", null, null, null, null, null, null, null, null, null, 0);
 
         ECSTaskTemplate result = child.merge(parent);
@@ -64,13 +64,13 @@ public class ECSTaskTemplateTest {
         ECSTaskTemplate child = new ECSTaskTemplate(
             "child-name", "child-label",
             null, "child-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
-            0, 0, 0, null, null, false, false,
+            false, 0, 0, 0, null, null, false, false,
             "child-containerUser", null, null, null, null, null, null, null, null, null, 0); // inheritFrom is null
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, "child-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
-            0, 0, 0, null, null, false, false,
+            false, 0, 0, 0, null, null, false, false,
             "child-containerUser", null, null, null, null, null, null, null, null, null, 0);
 
         ECSTaskTemplate result = child.merge(null);


### PR DESCRIPTION
Hello :wave:,

While using this plugin we ended up in the situation where multiple ECS agents running on the same EC2 instance ended up sharing the same workspace while preforming `parallel` stages.

The setup:

  * We run dockerised agents on an ECS cluster using this plugin.
  * The (contained) ECS agents can start further containers.
    To do so, they have access to the host's docker deamon socket.
  * For the ECS agent to share the workspace with the containers it creates on the host we mount the agent workspace of every ECS agent to the matching path on the host (any other setup leads the steps in the containers created by ECS agents to not find needed files).

Proposed solution in this PR: append a unique name (the agent name) to the remote FS root parameter so all ECS agents can mount the same directory (so they can share the workspace with "nested" containers and the file paths match as expected) without clashing among ECS tasks.

This feature is optional and disabled by default to the plugin works as it does now unless a different behaviour is requested.

Looking forward to your feedback.