### PR TITLE
Fixed Case insensitive match of overrides

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -173,7 +173,7 @@ public class ECSCloud extends Cloud {
     }
 
     public boolean isAllowedOverride(String override) {
-        List<String> allowedOverridesList = Arrays.asList(getAllowedOverrides().toLowerCase().replaceAll(" ", "").split(","));
+        List<String> allowedOverridesList = Arrays.asList(getAllowedOverrides().replaceAll(" ", "").split(","));
         if (allowedOverridesList.contains("all")) return true;
         return allowedOverridesList.contains(override);
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -175,7 +175,7 @@ public class ECSCloud extends Cloud {
     public boolean isAllowedOverride(String override) {
         List<String> allowedOverridesList = Arrays.asList(getAllowedOverrides().toLowerCase().replaceAll(" ", "").split(","));
         if (allowedOverridesList.contains("all")) return true;
-        return allowedOverridesList.contains(override);
+        return allowedOverridesList.contains(override.toLowerCase());
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -173,7 +173,7 @@ public class ECSCloud extends Cloud {
     }
 
     public boolean isAllowedOverride(String override) {
-        List<String> allowedOverridesList = Arrays.asList(getAllowedOverrides().replaceAll(" ", "").split(","));
+        List<String> allowedOverridesList = Arrays.asList(getAllowedOverrides().toLowerCase().replaceAll(" ", "").split(","));
         if (allowedOverridesList.contains("all")) return true;
         return allowedOverridesList.contains(override);
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -106,7 +106,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
 
     private void checkAllowedOverrides(ECSCloud cloud, ECSTaskTemplateStep step) throws AbortException {
         for (String override : step.getOverrides()) {
-            if(!cloud.isAllowedOverride(override.toLowerCase())) {
+            if(!cloud.isAllowedOverride(override)) {
                 LOGGER.log(Level.FINE, "Override {0} is not allowed", new Object[] { override });
                 throw new AbortException(String.format("Not allowed to override %s. Allowed overrides are %s", override, cloud.getAllowedOverrides()));
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -106,7 +106,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
 
     private void checkAllowedOverrides(ECSCloud cloud, ECSTaskTemplateStep step) throws AbortException {
         for (String override : step.getOverrides()) {
-            if(!cloud.isAllowedOverride(override)) {
+            if(!cloud.isAllowedOverride(override.toLowerCase())) {
                 LOGGER.log(Level.FINE, "Override {0} is not allowed", new Object[] { override });
                 throw new AbortException(String.format("Not allowed to override %s. Allowed overrides are %s", override, cloud.getAllowedOverrides()));
             }


### PR DESCRIPTION
This is a quick fix to allow overrides in declarative mode for some mixed-case parameters (such as inheritFrom).

Changes:
 - removed toLowerCase() in isAllowedOverride method

Tests:
 - tried to specify not allowed parameter: failed as expected
 - specified only allowed included mixed-case ones: worked as expected