### PR TITLE
Add executionRole support in declarative agent for fargate use

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -270,6 +270,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                            @Nullable List<ExtraHostEntry> extraHosts,
                            @Nullable List<MountPointEntry> mountPoints,
                            @Nullable List<PortMappingEntry> portMappings,
+                           @Nullable String executionRole,
                            @Nullable String taskrole,
                            @Nullable String inheritFrom) {
         // if the user enters a task definition override, always prefer to use it, rather than the jenkins template.
@@ -306,6 +307,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         this.extraHosts = extraHosts;
         this.mountPoints = mountPoints;
         this.portMappings = portMappings;
+        this.executionRole = executionRole;
         this.taskrole = taskrole;
         this.inheritFrom = inheritFrom;
     }
@@ -544,6 +546,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         List<MountPointEntry> mountPoints = CollectionUtils.isEmpty(this.mountPoints) ? parent.getMountPoints() : this.mountPoints;
         List<PortMappingEntry> portMappings = CollectionUtils.isEmpty(this.portMappings) ? parent.getPortMappings() : this.portMappings;
 
+        String executionRole = Strings.isNullOrEmpty(this.executionRole) ? parent.getExecutionRole() : this.executionRole;
         String taskrole = Strings.isNullOrEmpty(this.taskrole) ? parent.getTaskrole() : this.taskrole;
 
         ECSTaskTemplate merged = new ECSTaskTemplate(templateName,
@@ -567,6 +570,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                                                        extraHosts,
                                                        mountPoints,
                                                        portMappings,
+                                                       executionRole,
                                                        taskrole,
                                                        null);
         merged.setLogDriver(logDriver);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
@@ -39,6 +39,7 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
     private boolean assignPublicIp;
     private boolean privileged;
     private String containerUser;
+    private String executionRole;
     private String taskrole;
     private String inheritFrom;
     private String logDriver;
@@ -194,6 +195,16 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
         overrides.add("containerUser");
     }
 
+    public String getExecutionRole() {
+        return executionRole;
+    }
+
+    @DataBoundSetter
+    public void setExecutionRole(String executionRole) {
+        this.executionRole = executionRole;
+        overrides.add("executionRole");
+    }
+
     public String getTaskrole() {
         return taskrole;
     }
@@ -327,6 +338,10 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
 
         if (!StringUtils.isEmpty(containerUser)) {
             argMap.put("containerUser", containerUser);
+        }
+
+        if (!StringUtils.isEmpty(executionRole)) {
+            argMap.put("executionRole", executionRole);
         }
 
         if (!StringUtils.isEmpty(taskrole)) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
@@ -54,6 +54,7 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
     private boolean assignPublicIp;
     private boolean privileged;
     private String containerUser;
+    private String executionRole;
     private String taskrole;
     private String inheritFrom;
     private String logDriver;
@@ -213,6 +214,15 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
 
     public String getContainerUser() {
         return containerUser;
+    }
+
+    @DataBoundSetter
+    public void setExecutionRole(String executionRole) {
+        this.executionRole = executionRole;
+    }
+
+    public String getExecutionRole() {
+        return executionRole;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -94,6 +94,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
                                           step.getExtraHosts(),
                                           step.getMountPoints(),
                                           step.getPortMappings(),
+                                          step.getExecutionRole(),
                                           step.getTaskrole(),
                                           step.getInheritFrom());
         newTemplate.setLogDriver(step.getLogDriver());

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -106,6 +106,7 @@ public class ECSCloudTest {
             null,
             null,
             null,
+            null,
             null);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -96,6 +96,7 @@ public class ECSSlaveTest {
             null,
             null,
             null,
+            null,
             null);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
@@ -13,23 +13,22 @@ public class ECSTaskTemplateTest {
             "child-name", "child-label",
             null, "child-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
             0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, "parent");
+            "child-containerUser", null, null, null, null, null, null, null, "parent");
 
         ECSTaskTemplate parent = new ECSTaskTemplate(
             "parent-name", "parent-label",
             null, "parent-image", "parent-repository-credentials", "FARGATE", "parent-network-mode", "parent-remoteFSRoot",
             0, 0, 0, null, null, false, false,
-            "parent-containerUser", null, null, null, null, null, null, null);
+            "parent-containerUser", null, null, null, null, null, null, null, null);
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, "child-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
             0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, null);
+            "child-containerUser", null, null, null, null, null, null, null, null);
 
 
         ECSTaskTemplate result = child.merge(parent);
-
         assertTrue(EqualsBuilder.reflectionEquals(expected, result));
     }
 
@@ -40,19 +39,19 @@ public class ECSTaskTemplateTest {
             "child-name", "child-label",
             null, null, "child-repository-credentials", "EC2", "child-network-mode",  "child-remoteFSRoot", // image is set to null
             0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, "parent");
+            "child-containerUser", null, null, null, null, null, null, null, "parent");
 
         ECSTaskTemplate parent = new ECSTaskTemplate(
             "parent-name", "parent-label",
             null, "parent-image", "parent-repository-credentials", "FARGATE", "parent-network-mode", "parent-remoteFSRoot",
             0, 0, 0, null, null, false, false,
-            "parent-containerUser", null, null, null, null, null, null, null);
+            "parent-containerUser", null, null, null, null, null, null, null, null);
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, "parent-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
             0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, null);
+            "child-containerUser", null, null, null, null, null, null, null, null);
 
         ECSTaskTemplate result = child.merge(parent);
 
@@ -66,13 +65,13 @@ public class ECSTaskTemplateTest {
             "child-name", "child-label",
             null, "child-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
             0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, null); // inheritFrom is null
+            "child-containerUser", null, null, null, null, null, null, null, null); // inheritFrom is null
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, "child-image", "child-repository-credentials", "EC2", "child-network-mode", "child-remoteFSRoot",
             0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, null);
+            "child-containerUser", null, null, null, null, null, null, null, null);
 
         ECSTaskTemplate result = child.merge(null);
 


### PR DESCRIPTION
This now allows us to utilise declarative configuration for fargate ecs agents.

It does appear that cpu / memory have to be specified as well in the declaration but I've not had a chance to look into that yet. 

Fixes #95