### PR TITLE
Make ECS task polling interval customizable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -86,6 +86,7 @@ public class ECSCloud extends Cloud {
     private String jenkinsUrl;
     private int retentionTimeout = DescriptorImpl.DEFAULT_RETENTION_TIMEOUT;
     private int slaveTimeoutInSeconds = DescriptorImpl.DEFAULT_SLAVE_TIMEOUT_IN_SECONDS;
+    private int taskPollingIntervalInSeconds = DescriptorImpl.DEFAULT_TASK_POLLING_INTERVAL_IN_SECONDS;
     private ECSService ecsService;
     private String allowedOverrides;
     private int maxCpu;
@@ -275,6 +276,23 @@ public class ECSCloud extends Cloud {
         this.retentionTimeout = retentionTimeout;
     }
 
+
+    public int getTaskPollingIntervalInSeconds() {
+        // this is only needed for edge cases, where in the config was nothing set
+        // and then 0 is assumed as default which breaks things.
+
+        if (this.taskPollingIntervalInSeconds == 0) {
+            return DescriptorImpl.DEFAULT_TASK_POLLING_INTERVAL_IN_SECONDS;
+        } else {
+            return this.taskPollingIntervalInSeconds;
+        }
+    }
+
+    @DataBoundSetter
+    public void setTaskPollingIntervalInSeconds(int taskPollingIntervalInSeconds) {
+        this.taskPollingIntervalInSeconds = taskPollingIntervalInSeconds;
+    }
+
     public int getMaxCpu() {
         return maxCpu;
     }
@@ -361,7 +379,8 @@ public class ECSCloud extends Cloud {
     @Extension
     public static class DescriptorImpl extends Descriptor<Cloud> {
         public static final int DEFAULT_RETENTION_TIMEOUT = 5;
-        public static final int DEFAULT_SLAVE_TIMEOUT_IN_SECONDS= 900;
+        public static final int DEFAULT_SLAVE_TIMEOUT_IN_SECONDS = 900;
+        public static final int DEFAULT_TASK_POLLING_INTERVAL_IN_SECONDS = 1;
         public static final String DEFAULT_ALLOWED_OVERRIDES = "";
         private static String CLOUD_NAME_PATTERN = "[a-z|A-Z|0-9|_|-]{1,127}";
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSLauncher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSLauncher.java
@@ -138,7 +138,7 @@ public class ECSLauncher extends JNLPLauncher {
 
                 LOGGER.log(INFO, "[{0}]: Waiting for agent to start", new Object[]{agent.getNodeName()});
                 logger.printf("Waiting for agent to start: %1$s%n", agent.getNodeName());
-                Thread.sleep(1000);
+                Thread.sleep(cloud.getTaskPollingIntervalInSeconds() * 1000);
             }
 
             if (!taskRunning) {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -60,11 +60,14 @@
     <f:entry field="jenkinsUrl" title="${%Alternative Jenkins URL}" description="If needed, the Jenkins URL can be overwritten with this property (e.g. to support other HTTP(S) endpoints due to reverse proxies or firewalling). By default the URL from the global Jenkins configuration is used.">
       <f:textbox />
     </f:entry>
-    <f:entry field="slaveTimeoutInSeconds" title="${%ECS task creation timeout}" description="Timeout (in second) for ECS task to be created, useful if you use large docker agent image, because the host will take more time to pull the docker image">
+    <f:entry field="slaveTimeoutInSeconds" title="${%ECS task creation timeout}" description="Timeout (in seconds) for ECS task to be created, useful if you use large docker agent image, because the host will take more time to pull the docker image">
       <f:textbox default="${descriptor.defaultSlaveTimeoutInSeconds}" />
     </f:entry>
     <f:entry field="retentionTimeout" title="${%Container Cleanup Timeout (minutes)}" description="Timeout (in minutes) for how long instances can be idle before they are cleaned up. Should be at least 1.">
       <f:textbox default="${descriptor.defaultRetentionTimeout}"/>
+    </f:entry>
+    <f:entry field="taskPollingIntervalInSeconds" title="${%ECS task polling interval}" description="Polling interval (in seconds) to use when waiting for ECS tasks to enter the RUNNING state. Use higher values to avoid throtting from AWS if you're running many tasks in one account.">
+      <f:textbox default="${descriptor.defaultTaskPollingIntervalInSeconds}" />
     </f:entry>
   </f:advanced>
 


### PR DESCRIPTION
When deploying a large number of ECS agents (200+ concurrently), AWS often throttles ECS API calls due to the large number of `DescribeTasks` calls being made waiting for the agent task to enter the RUNNING state: https://github.com/francoiscampbell/amazon-ecs-plugin/blob/1646c51035390d44c8be8edfa69cf98e48cc1354/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSLauncher.java#L122

This PR makes this polling interval customizable, since a small delay in agents coming online is acceptable in exchange for not being subject to AWS throttling.