### PR TITLE
Remove dynamic task templates from the template map

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -376,6 +376,14 @@ public class ECSCloud extends Cloud {
         TaskTemplateMap.get().removeTemplate(this, t);
     }
 
+    /**
+     * Remove a dynamic task template from the template map.
+     * @param t the template to remove
+     */
+    public void removeDynamicTemplateFromTemplateMap(ECSTaskTemplate t) {
+        TaskTemplateMap.get().removeTemplate(this, t);
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<Cloud> {
         public static final int DEFAULT_RETENTION_TIMEOUT = 5;

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -185,8 +185,9 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
             if (c instanceof ECSCloud) {
                 ECSCloud ecsCloud = (ECSCloud) c;
                 if (override != null){
-                    LOGGER.log(Level.INFO, "Do not remove custom task template from cloud {0}",
+                    LOGGER.log(Level.INFO, "Remove custom task template from map, not cloud {0}",
                         new Object[] { c.name});
+                    ecsCloud.removeDynamicTemplateFromTemplateMap(taskTemplate);
                     return;
                 } else {
                     LOGGER.log(Level.INFO, "Removing task template {1} from cloud {0}",


### PR DESCRIPTION
This fixes a memory leak bug that manifests itself when creating ECS Task templates on a pipelined job while also using task definition overrides. You can see this bug in effect by running a pipeline job like so
```
ecsTaskTemplate(
    cloud: 'YourCloudHere',
    label: "LabelThatShouldOnlyExistDuringJobRun",
    name: 'name',
    containerUser: 'jenkins',
    remoteFSRoot: '/home/jenkins',
    overrides: [],
    taskDefinitionOverride: 'arn:aws:ecs:us-east-1::task-definition/${env.task}',
) {
...
}
```
When the pipeline is running you should be able to run ```Jenkins.instance.getLabels()``` in the Jenkins script console and see the label. When the pipeline job finishes this label should be cleaned up, but running the snippet again will show it lingers. I believe this bug can be tracked to this PR https://github.com/jenkinsci/amazon-ecs-plugin/pull/109, where it ensured not to clean up Task Definitions in AWS that were never created to begin with, but forgot to delete created templates from the plugin's template map.

