### PR TITLE
#139 Fix fargate run/merge issue, add tests, merge in pipeline scripts config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
         <jenkins.version>2.107.3</jenkins.version>
         <java.level>8</java.level>
         <mockito.version>2.0.2-beta</mockito.version>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
     <developers>

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSLauncher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSLauncher.java
@@ -90,7 +90,7 @@ public class ECSLauncher extends JNLPLauncher {
         ECSComputer ecsComputer = (ECSComputer) computer;
         computer.setAcceptingTasks(false);
 
-        ECSSlave agent = (ECSSlave)ecsComputer.getNode();
+        ECSSlave agent = ecsComputer.getNode();
         if (agent == null) {
             throw new IllegalStateException("Node has been removed, cannot launch " + computer.getName());
         }
@@ -177,9 +177,7 @@ public class ECSLauncher extends JNLPLauncher {
             LOGGER.log(Level.FINER, "[{0}]: Removing Jenkins node", agent.getNodeName());
             try {
                 agent.terminate();
-            } catch (InterruptedException e) {
-                LOGGER.log(Level.WARNING, "Unable to remove Jenkins node", e);
-            } catch (IOException e) {
+            } catch (InterruptedException | IOException e) {
                 LOGGER.log(Level.WARNING, "Unable to remove Jenkins node", e);
             }
             throw Throwables.propagate(ex);
@@ -199,7 +197,7 @@ public class ECSLauncher extends JNLPLauncher {
         TaskDefinition taskDefinition;
 
         if (template.getTaskDefinitionOverride() == null) {
-            taskDefinition = ecsService.registerTemplate(cloud, template);
+            taskDefinition = ecsService.registerTemplate(cloud.getDisplayName(), template);
 
         } else {
             LOGGER.log(Level.FINE, "[{0}]: Attempting to find task definition family or ARN: {1}", new Object[] {nodeName, template.getTaskDefinitionOverride()});
@@ -215,7 +213,7 @@ public class ECSLauncher extends JNLPLauncher {
         return taskDefinition;
     }
 
-    private Task runECSTask(TaskDefinition taskDefinition, ECSCloud cloud, ECSTaskTemplate template, ECSService ecsService, ECSSlave agent) throws IOException, AbortException {
+    private Task runECSTask(TaskDefinition taskDefinition, ECSCloud cloud, ECSTaskTemplate template, ECSService ecsService, ECSSlave agent) throws IOException {
 
         LOGGER.log(Level.INFO, "[{0}]: Starting agent with task definition {1}}", new Object[]{agent.getNodeName(), taskDefinition.getTaskDefinitionArn()});
 
@@ -239,7 +237,7 @@ public class ECSLauncher extends JNLPLauncher {
     }
 
     private Collection<String> getDockerRunCommand(ECSSlave slave, String jenkinsUrl) {
-        Collection<String> command = new ArrayList<String>();
+        Collection<String> command = new ArrayList<>();
         command.add("-url");
         command.add(jenkinsUrl);
         if (StringUtils.isNotBlank(tunnel)) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -27,6 +27,7 @@ package com.cloudbees.jenkins.plugins.amazonecs;
 
 import com.amazonaws.services.ecs.model.*;
 import com.amazonaws.services.ecs.model.Volume;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -35,6 +36,7 @@ import hudson.model.labels.LabelAtom;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -47,9 +49,13 @@ import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 
 import java.io.IOException;
+import java.lang.reflect.Modifier;
 import java.util.*;
 
 import java.io.Serializable;
+import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
+
 import com.google.common.base.Strings;
 
 /**
@@ -496,6 +502,17 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
 
     public String getTemplateName() {return templateName; }
 
+    @Override
+    public String toString() {
+        return Arrays.stream(this.getClass().getDeclaredFields()).filter(f -> !Modifier.isStatic(f.getModifiers()) ).map(f -> {
+            try {
+                return String.format("%s: %s",f.getName(),f.get(this));
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException();
+            }
+        }).collect(Collectors.joining("\n"));
+    }
+
     public static class LogDriverOption extends AbstractDescribableImpl<LogDriverOption> implements Serializable {
         private static final long serialVersionUID = 8585792353105873086L;
         public String name, value;
@@ -556,41 +573,53 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         return placementStrategies;
     }
 
+    /**
+     * This merge does not take an into consideration the child intentionally setting empty values for parameters like "entrypoint" - in fact
+     * it's not uncommon to override the entrypoint of a container and set it to blank so you can use your own entrypoint as part of the command.
+     * What's really needed is a "MergeStrategy `BinaryOperator<ECSTaskTemplate>` that's user selectable.
+     * @param parent inherit settings from
+     * @return a 'merged' template
+     */
     public ECSTaskTemplate merge(ECSTaskTemplate parent) {
         if(parent == null) {
             return this;
         }
+        String templateName = isNullOrEmpty(this.templateName) ? parent.getTemplateName() : this.templateName;
+        String label = isNullOrEmpty(this.label) ? parent.getLabel() : this.label;
+        String taskDefinitionOverride = isNullOrEmpty(this.taskDefinitionOverride) ? parent.getTaskDefinitionOverride() : this.taskDefinitionOverride;
+        String image = isNullOrEmpty(this.image) ? parent.getImage() : this.image;
+        String repositoryCredentials = isNullOrEmpty(this.repositoryCredentials) ? parent.getRepositoryCredentials() : this.repositoryCredentials;
+        String launchType = isNullOrEmpty(this.launchType) ? parent.getLaunchType() : this.launchType;
+        String networkMode = isNullOrEmpty(this.networkMode) ? parent.getNetworkMode() : this.networkMode;
+        String remoteFSRoot = isNullOrEmpty(this.remoteFSRoot) ? parent.getRemoteFSRoot() : this.remoteFSRoot;
 
-        String templateName = Strings.isNullOrEmpty(this.templateName) ? parent.getTemplateName() : this.templateName;
-        String label = Strings.isNullOrEmpty(this.label) ? parent.getLabel() : this.label;
-        String taskDefinitionOverride = Strings.isNullOrEmpty(this.taskDefinitionOverride) ? parent.getTaskDefinitionOverride() : this.taskDefinitionOverride;
-        String image = Strings.isNullOrEmpty(this.image) ? parent.getImage() : this.image;
-        String repositoryCredentials = Strings.isNullOrEmpty(this.repositoryCredentials) ? parent.getRepositoryCredentials() : this.repositoryCredentials;
-        String launchType = Strings.isNullOrEmpty(this.launchType) ? parent.getLaunchType() : this.launchType;
-        String networkMode = Strings.isNullOrEmpty(this.networkMode) ? parent.getNetworkMode() : this.networkMode;
-        String remoteFSRoot = Strings.isNullOrEmpty(this.remoteFSRoot) ? parent.getRemoteFSRoot() : this.remoteFSRoot;
+        // Bug potential here. If I intenionally set it false in the child, then it will be ignored and take the parent. Need null to mean 'unset'
         boolean uniqueRemoteFSRoot = this.uniqueRemoteFSRoot || parent.getUniqueRemoteFSRoot();
         int memory = this.memory == 0 ? parent.getMemory() : this.memory;
         int memoryReservation = this.memoryReservation == 0 ? parent.getMemoryReservation() : this.memoryReservation;
         int cpu = this.cpu == 0 ? parent.getCpu() : this.cpu;
         int sharedMemorySize = this.sharedMemorySize == 0 ? parent.getSharedMemorySize() : this.sharedMemorySize;
-        String subnets = Strings.isNullOrEmpty(this.subnets) ? parent.getSubnets() : this.subnets;
-        String securityGroups = Strings.isNullOrEmpty(this.securityGroups) ? parent.getSecurityGroups() : this.securityGroups;
+        String subnets = isNullOrEmpty(this.subnets) ? parent.getSubnets() : this.subnets;
+        String securityGroups = isNullOrEmpty(this.securityGroups) ? parent.getSecurityGroups() : this.securityGroups;
+
+        // Bug potential here. If I intenionally set it false in the child, then it will be ignored and take the parent. Need null to mean 'unset'
         boolean assignPublicIp = this.assignPublicIp ? this.assignPublicIp : parent.getAssignPublicIp();
+
+        // Bug potential here. If I intenionally set it false in the child, then it will be ignored and take the parent. Need null to mean 'unset'
         boolean privileged = this.privileged ? this.privileged : parent.getPrivileged();
-        String containerUser = Strings.isNullOrEmpty(this.containerUser) ? parent.getContainerUser() : this.containerUser;
-        String logDriver = Strings.isNullOrEmpty(this.logDriver) ? parent.getLogDriver() : this.logDriver;
+        String containerUser = isNullOrEmpty(this.containerUser) ? parent.getContainerUser() : this.containerUser;
+        String logDriver = isNullOrEmpty(this.logDriver) ? parent.getLogDriver() : this.logDriver;
 
         // TODO probably merge lists with parent instead of overriding them
-        List<LogDriverOption> logDriverOptions = CollectionUtils.isEmpty(this.logDriverOptions) ? parent.getLogDriverOptions() : this.logDriverOptions;
-        List<EnvironmentEntry> environments = CollectionUtils.isEmpty(this.environments) ? parent.getEnvironments() : this.environments;
-        List<ExtraHostEntry> extraHosts = CollectionUtils.isEmpty(this.extraHosts) ? parent.getExtraHosts() : this.extraHosts;
-        List<MountPointEntry> mountPoints = CollectionUtils.isEmpty(this.mountPoints) ? parent.getMountPoints() : this.mountPoints;
-        List<PortMappingEntry> portMappings = CollectionUtils.isEmpty(this.portMappings) ? parent.getPortMappings() : this.portMappings;
-        List<PlacementStrategyEntry> placementStrategies = CollectionUtils.isEmpty(this.placementStrategies) ? parent.getPlacementStrategies() : this.placementStrategies;
+        List<LogDriverOption> logDriverOptions = isEmpty(this.logDriverOptions) ? parent.getLogDriverOptions() : this.logDriverOptions;
+        List<EnvironmentEntry> environments = isEmpty(this.environments) ? parent.getEnvironments() : this.environments;
+        List<ExtraHostEntry> extraHosts = isEmpty(this.extraHosts) ? parent.getExtraHosts() : this.extraHosts;
+        List<MountPointEntry> mountPoints = isEmpty(this.mountPoints) ? parent.getMountPoints() : this.mountPoints;
+        List<PortMappingEntry> portMappings = isEmpty(this.portMappings) ? parent.getPortMappings() : this.portMappings;
+        List<PlacementStrategyEntry> placementStrategies = isEmpty(this.placementStrategies) ? parent.getPlacementStrategies() : this.placementStrategies;
 
-        String executionRole = Strings.isNullOrEmpty(this.executionRole) ? parent.getExecutionRole() : this.executionRole;
-        String taskrole = Strings.isNullOrEmpty(this.taskrole) ? parent.getTaskrole() : this.taskrole;
+        String executionRole = isNullOrEmpty(this.executionRole) ? parent.getExecutionRole() : this.executionRole;
+        String taskrole = isNullOrEmpty(this.taskrole) ? parent.getTaskrole() : this.taskrole;
 
         ECSTaskTemplate merged = new ECSTaskTemplate(templateName,
                                                        label,
@@ -620,6 +649,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                                                        null,
                                                         sharedMemorySize);
         merged.setLogDriver(logDriver);
+        merged.setEntrypoint(entrypoint);
 
         return merged;
     }
@@ -965,5 +995,145 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
             }
             return FormValidation.ok();
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ECSTaskTemplate that = (ECSTaskTemplate) o;
+
+        if (memory != that.memory) {
+            return false;
+        }
+        if (memoryReservation != that.memoryReservation) {
+            return false;
+        }
+        if (cpu != that.cpu) {
+            return false;
+        }
+        if (sharedMemorySize != that.sharedMemorySize) {
+            return false;
+        }
+        if (assignPublicIp != that.assignPublicIp) {
+            return false;
+        }
+        if (privileged != that.privileged) {
+            return false;
+        }
+        if (uniqueRemoteFSRoot != that.uniqueRemoteFSRoot) {
+            return false;
+        }
+        if (!templateName.equals(that.templateName)) {
+            return false;
+        }
+        if (label != null ? !label.equals(that.label) : that.label != null) {
+            return false;
+        }
+        if (taskDefinitionOverride != null ? !taskDefinitionOverride.equals(that.taskDefinitionOverride) : that.taskDefinitionOverride != null) {
+            return false;
+        }
+        if (!image.equals(that.image)) {
+            return false;
+        }
+        if (remoteFSRoot != null ? !remoteFSRoot.equals(that.remoteFSRoot) : that.remoteFSRoot != null) {
+            return false;
+        }
+        if (subnets != null ? !subnets.equals(that.subnets) : that.subnets != null) {
+            return false;
+        }
+        if (securityGroups != null ? !securityGroups.equals(that.securityGroups) : that.securityGroups != null) {
+            return false;
+        }
+        if (dnsSearchDomains != null ? !dnsSearchDomains.equals(that.dnsSearchDomains) : that.dnsSearchDomains != null) {
+            return false;
+        }
+        if (entrypoint != null ? !entrypoint.equals(that.entrypoint) : that.entrypoint != null) {
+            return false;
+        }
+        if (taskrole != null ? !taskrole.equals(that.taskrole) : that.taskrole != null) {
+            return false;
+        }
+        if (executionRole != null ? !executionRole.equals(that.executionRole) : that.executionRole != null) {
+            return false;
+        }
+        if (repositoryCredentials != null ? !repositoryCredentials.equals(that.repositoryCredentials) : that.repositoryCredentials != null) {
+            return false;
+        }
+        if (jvmArgs != null ? !jvmArgs.equals(that.jvmArgs) : that.jvmArgs != null) {
+            return false;
+        }
+        if (mountPoints != null ? !mountPoints.equals(that.mountPoints) : that.mountPoints != null) {
+            return false;
+        }
+        if (!launchType.equals(that.launchType)) {
+            return false;
+        }
+        if (!networkMode.equals(that.networkMode)) {
+            return false;
+        }
+        if (containerUser != null ? !containerUser.equals(that.containerUser) : that.containerUser != null) {
+            return false;
+        }
+        if (environments != null ? !environments.equals(that.environments) : that.environments != null) {
+            return false;
+        }
+        if (extraHosts != null ? !extraHosts.equals(that.extraHosts) : that.extraHosts != null) {
+            return false;
+        }
+        if (portMappings != null ? !portMappings.equals(that.portMappings) : that.portMappings != null) {
+            return false;
+        }
+        if (placementStrategies != null ? !placementStrategies.equals(that.placementStrategies) : that.placementStrategies != null) {
+            return false;
+        }
+        if (logDriver != null ? !logDriver.equals(that.logDriver) : that.logDriver != null) {
+            return false;
+        }
+        if (logDriverOptions != null ? !logDriverOptions.equals(that.logDriverOptions) : that.logDriverOptions != null) {
+            return false;
+        }
+        return inheritFrom != null ? inheritFrom.equals(that.inheritFrom) : that.inheritFrom == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = templateName.hashCode();
+        result = 31 * result + (label != null ? label.hashCode() : 0);
+        result = 31 * result + (taskDefinitionOverride != null ? taskDefinitionOverride.hashCode() : 0);
+        result = 31 * result + image.hashCode();
+        result = 31 * result + (remoteFSRoot != null ? remoteFSRoot.hashCode() : 0);
+        result = 31 * result + memory;
+        result = 31 * result + memoryReservation;
+        result = 31 * result + cpu;
+        result = 31 * result + sharedMemorySize;
+        result = 31 * result + (subnets != null ? subnets.hashCode() : 0);
+        result = 31 * result + (securityGroups != null ? securityGroups.hashCode() : 0);
+        result = 31 * result + (assignPublicIp ? 1 : 0);
+        result = 31 * result + (dnsSearchDomains != null ? dnsSearchDomains.hashCode() : 0);
+        result = 31 * result + (entrypoint != null ? entrypoint.hashCode() : 0);
+        result = 31 * result + (taskrole != null ? taskrole.hashCode() : 0);
+        result = 31 * result + (executionRole != null ? executionRole.hashCode() : 0);
+        result = 31 * result + (repositoryCredentials != null ? repositoryCredentials.hashCode() : 0);
+        result = 31 * result + (jvmArgs != null ? jvmArgs.hashCode() : 0);
+        result = 31 * result + (mountPoints != null ? mountPoints.hashCode() : 0);
+        result = 31 * result + launchType.hashCode();
+        result = 31 * result + networkMode.hashCode();
+        result = 31 * result + (privileged ? 1 : 0);
+        result = 31 * result + (uniqueRemoteFSRoot ? 1 : 0);
+        result = 31 * result + (containerUser != null ? containerUser.hashCode() : 0);
+        result = 31 * result + (environments != null ? environments.hashCode() : 0);
+        result = 31 * result + (extraHosts != null ? extraHosts.hashCode() : 0);
+        result = 31 * result + (portMappings != null ? portMappings.hashCode() : 0);
+        result = 31 * result + (placementStrategies != null ? placementStrategies.hashCode() : 0);
+        result = 31 * result + (logDriver != null ? logDriver.hashCode() : 0);
+        result = 31 * result + (logDriverOptions != null ? logDriverOptions.hashCode() : 0);
+        result = 31 * result + (inheritFrom != null ? inheritFrom.hashCode() : 0);
+        return result;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/SerializableSupplier.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/SerializableSupplier.java
@@ -1,0 +1,13 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+/**
+ * @author cbongiorno on 2020-04-13.
+ * This is necessary to overcome the fact that jenkins needs everything serializable, but we also don't want it to attempt to integrate with AWS
+ * We need to allow for mocks in our tests but the real thing in prod
+ */
+@FunctionalInterface
+public interface SerializableSupplier<T> extends Supplier<T>, Serializable {
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.plugins.amazonecs.pipeline;
 
+import com.cloudbees.jenkins.plugins.amazonecs.SerializableSupplier;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
@@ -345,7 +346,7 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
     public StepExecution start(StepContext stepContext) throws Exception {
         LOGGER.log(Level.FINE, "In ECSTaskTemplateStep start. label: {0}", label);
         LOGGER.log(Level.FINE, "In ECSTaskTemplateStep start. cloud: {0}", cloud);
-        return new ECSTaskTemplateStepExecution(this, stepContext, Jenkins.get().clouds);
+        return new ECSTaskTemplateStepExecution(this, stepContext, (SerializableSupplier<Jenkins.CloudList>)() -> Jenkins.get().clouds);
     }
 
     @Extension(optional = true)

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSServiceTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSServiceTest.java
@@ -1,0 +1,26 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import static org.junit.Assert.*;
+import org.junit.Ignore;
+import org.junit.Test;
+
+
+/**
+ * Whoever wrote the original class should implement some tests
+ */
+public class ECSServiceTest {
+
+
+    @Test
+    @Ignore
+    public void testDescribeTask() {
+
+    }
+
+    @Test
+    @Ignore
+    public void testStopTask() {
+//        ECSService service = new ECSService("us-east-1");
+
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
@@ -2,27 +2,22 @@ package com.cloudbees.jenkins.plugins.amazonecs.pipeline;
 
 import com.cloudbees.jenkins.plugins.amazonecs.ECSCloud;
 import com.cloudbees.jenkins.plugins.amazonecs.ECSTaskTemplate;
-import hudson.model.Hudson;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import com.cloudbees.jenkins.plugins.amazonecs.SerializableSupplier;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import static org.mockito.Matchers.any;
-import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Random;
 import java.util.UUID;
 
@@ -66,7 +61,7 @@ public class ECSTaskTemplateStepExecutionTest {
         clouds.add(cloud);
         step.setOverrides(Arrays.asList("image","taskRole"));
 
-        ECSTaskTemplateStepExecution executionStep = new ECSTaskTemplateStepExecution(step, context, clouds);
+        ECSTaskTemplateStepExecution executionStep = new ECSTaskTemplateStepExecution(step, context, (SerializableSupplier<Jenkins.CloudList>) () -> clouds);
         Random r = new Random();
         ECSTaskTemplate expected = new ECSTaskTemplate(
                 "",

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
@@ -1,0 +1,172 @@
+package com.cloudbees.jenkins.plugins.amazonecs.pipeline;
+
+import com.cloudbees.jenkins.plugins.amazonecs.ECSCloud;
+import com.cloudbees.jenkins.plugins.amazonecs.ECSTaskTemplate;
+import hudson.model.Hudson;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import static org.mockito.Matchers.any;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * @author cbongiorno on 2020-04-09.
+ */
+public class ECSTaskTemplateStepExecutionTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    private ECSTaskTemplateStep step;
+
+
+    @Before
+    public void setUp() throws Exception {
+
+
+    }
+
+    @Test
+    public void testMerge() throws Exception {
+        StepContext  context = mock(StepContext.class);
+        BodyInvoker invoker    = mock(BodyInvoker.class);
+        when(context.newBodyInvoker()).thenReturn(invoker);
+        when(invoker.withCallback(any(BodyExecutionCallback.TailCall.class))).thenReturn(invoker);
+
+
+        ECSCloud cloud = mock(ECSCloud.class);
+        when(cloud.getDisplayName()).thenReturn("my-cloud");
+        when(cloud.isAllowedOverride("image")).thenReturn(true);
+        when(cloud.isAllowedOverride("taskRole")).thenReturn(true);
+
+        ECSTaskTemplate parentTemplate = getTaskTemplate("parent-name", "parent-label");
+        when(cloud.findParentTemplate(parentTemplate.getLabel())).thenReturn(parentTemplate);
+        when(cloud.canProvision(parentTemplate.getLabel())).thenReturn(true);
+
+        step = new ECSTaskTemplateStep("child-label", "child-name");
+        
+        step.setInheritFrom(parentTemplate.getLabel());
+
+        Jenkins.CloudList clouds = new Jenkins.CloudList();
+        clouds.add(cloud);
+        step.setOverrides(Arrays.asList("image","taskRole"));
+
+        ECSTaskTemplateStepExecution executionStep = new ECSTaskTemplateStepExecution(step, context, clouds);
+        Random r = new Random();
+        ECSTaskTemplate expected = new ECSTaskTemplate(
+                "",
+                "child-label",
+                UUID.randomUUID().toString(),
+                "image-override",
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                false,
+                r.nextInt(123),
+                r.nextInt(456),
+                r.nextInt(1024),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                r.nextBoolean(),
+                r.nextBoolean(),
+                UUID.randomUUID().toString(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                UUID.randomUUID().toString(),
+                null,
+                "override-task-role",
+                null,
+                r.nextInt(123));
+
+        // Overriding the entrypoint is inconsistent... why? You can't do it in the step
+//        expected.setEntrypoint("entrypoint-override");
+        step.setInheritFrom(parentTemplate.getLabel());
+
+        step.setLogDriver(expected.getLogDriver());
+
+        step.setImage(expected.getImage());
+        step.setLaunchType(expected.getLaunchType());
+        step.setTaskDefinitionOverride(expected.getTaskDefinitionOverride());
+        step.setRepositoryCredentials(expected.getRepositoryCredentials());
+        step.setNetworkMode(expected.getNetworkMode());
+        step.setRemoteFSRoot(expected.getRemoteFSRoot());
+        step.setUniqueRemoteFSRoot(expected.getUniqueRemoteFSRoot());
+        step.setMemory(expected.getMemory());
+        step.setMemoryReservation(expected.getMemoryReservation());
+        step.setCpu(expected.getCpu());
+        step.setSubnets(expected.getSubnets());
+        step.setSecurityGroups(expected.getSecurityGroups());
+        step.setAssignPublicIp(expected.getAssignPublicIp());
+        step.setPrivileged(expected.getPrivileged());
+        step.setContainerUser(expected.getContainerUser());
+        step.setLogDriverOptions(expected.getLogDriverOptions());
+        step.setEnvironments(expected.getEnvironments());
+        step.setExtraHosts(expected.getExtraHosts());
+        step.setMountPoints(expected.getMountPoints());
+        step.setPortMappings(expected.getPortMappings());
+        step.setExecutionRole(expected.getExecutionRole());
+        step.setPlacementStrategies(expected.getPlacementStrategies());
+        step.setTaskrole(expected.getTaskrole());
+        step.setSharedMemorySize(expected.getSharedMemorySize());
+
+        when(invoker.withContext(step)).thenReturn(invoker);
+        executionStep.start();
+
+        verify(cloud,times(1)).addDynamicTemplate(expected);
+
+
+
+    }
+    private ECSTaskTemplate getTaskTemplate() {
+        return getTaskTemplate(UUID.randomUUID().toString(),UUID.randomUUID().toString());
+    }
+    private ECSTaskTemplate getTaskTemplate(String templateName, String label) {
+        return new ECSTaskTemplate(
+                templateName,
+                label,
+                "",
+                "image",
+                "repositoryCredentials",
+                "launchType",
+                "networkMode",
+                "remoteFSRoot",
+                false,
+                0,
+                0,
+                0,
+                null,
+                null,
+                false,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0);
+    }
+}


### PR DESCRIPTION
#139 

This set of changes includes numerous fixes 

- When getting an error from AWS after a task is complete (like if it can't find the task family), don't try to find a task version on `null`
- If `ECSCloud.provision` could not find a template, this produced an NPE
- added more, and clearer logs
- *important* fixed the match logic for `canProvision` as it was using `String.matches` instead of `LabelAtom.matches` which is a regex match not a set intersection. In addition, the match was backwards.
- *Important* under fargate, "addTemplateDyanamic" was simply not merging at all - this is fixed. 
- adds mocking to the ECSCloudTest so that tests don't try to create AMZN resources (this should be a seperate test) as this may discourage OSS devs from testing if they think it will cost them money.

##Documentation updated##
Added clearer example, and also added steps for debugging in an IDE.
