### PR TITLE
Update the default agent name to the new name for the image

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -35,7 +35,7 @@
       <f:textbox />
   </f:entry>
   <f:entry title="${%Docker Image}" field="image">
-    <f:textbox default="jenkins/jnlp-slave" />
+    <f:textbox default="jenkins/inbound-agent" />
   </f:entry>
   <f:entry title="${%Secrets manager ARN}" field="repositoryCredentials">
     <f:textbox />

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-image.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-image.html
@@ -28,5 +28,5 @@ Docker image to run as a jenkins agent.
 This image will be ran passing command "<code>-url [jenkins url] [slave jnlp secret] [slave name]</code>". Those are
 the parameters expected by
 <a href="https://github.com/jenkinsci/remoting/blob/master/src/main/java/hudson/remoting/jnlp/Main.java">Jenkins remoting JNLP launcher</a>.
-You can use or inherit from  <a href="https://hub.docker.com/r/jenkins/jnlp-slave/">jenkins/jnlp-slave</a>
+You can use or inherit from  <a href="https://hub.docker.com/r/jenkins/inbound-agent/">jenkins/inbound-agent</a>
 Docker image so you dont' have to wory about those implementation details.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep/config.jelly
@@ -43,7 +43,7 @@
       <f:textbox />
   </f:entry>
   <f:entry title="${%Docker Image}" field="image">
-    <f:textbox default="jenkins/jnlp-slave" />
+    <f:textbox default="jenkins/inbound-agent" />
   </f:entry>
   <f:entry name="launchType" title="${%Launch type}" field="launchType">
     <f:select />


### PR DESCRIPTION
The `jenkins\jnlp-slave` image has been renamed to `jenkins\inbound-agent`. This updates the default image name and documentation to point to the new image.