### PR TITLE
Ignore template name and memory form field validation if a task definition override is used

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -974,7 +974,13 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
             return options;
         }
 
-        public FormValidation doCheckTemplateName(@QueryParameter String value) throws IOException, ServletException {
+        public FormValidation doCheckTemplateName(
+            @QueryParameter String value,
+            @QueryParameter String taskDefinitionOverride
+        ) throws IOException, ServletException {
+            if (!isNullOrEmpty(taskDefinitionOverride)) {
+                return FormValidation.ok();
+            }
             if (value.length() > 0 && value.length() <= 127 && value.matches(TEMPLATE_NAME_PATTERN)) {
                 return FormValidation.ok();
             }
@@ -996,11 +1002,25 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         }
 
         /* we validate both memory and memoryReservation fields to the same rules */
-        public FormValidation doCheckMemory(@QueryParameter("memory") int memory, @QueryParameter("memoryReservation") int memoryReservation) throws IOException, ServletException {
+        public FormValidation doCheckMemory(
+            @QueryParameter("memory") int memory,
+            @QueryParameter("memoryReservation") int memoryReservation,
+            @QueryParameter String taskDefinitionOverride
+        ) throws IOException, ServletException {
+            if (!isNullOrEmpty(taskDefinitionOverride)) {
+                return FormValidation.ok();
+            }
             return validateMemorySettings(memory,memoryReservation);
         }
 
-        public FormValidation doCheckMemoryReservation(@QueryParameter("memory") int memory, @QueryParameter("memoryReservation") int memoryReservation) throws IOException, ServletException {
+        public FormValidation doCheckMemoryReservation(
+            @QueryParameter("memory") int memory,
+            @QueryParameter("memoryReservation") int memoryReservation,
+            @QueryParameter String taskDefinitionOverride
+        ) throws IOException, ServletException {
+            if (!isNullOrEmpty(taskDefinitionOverride)) {
+                return FormValidation.ok();
+            }
             return validateMemorySettings(memory,memoryReservation);
         }
 


### PR DESCRIPTION
When an ECS task definition override is used, the template name and memory fields are ignored and shouldn't be validated.

Before:
![Screen Shot 2020-04-20 at 11 55 27 AM](https://user-images.githubusercontent.com/3876970/79772661-5655f780-82fe-11ea-80dc-83db2a7135ab.png)

After:
![Screen Shot 2020-04-20 at 11 55 48 AM](https://user-images.githubusercontent.com/3876970/79772671-58b85180-82fe-11ea-9516-b15588607c51.png)

To reproduce:
- Create a new task template in a new or existing cloud
- See the failing validation because the name and memory fields are empty
- Type in anything in the task definition field (we don't validate that it's a valid ARN or that the taskdef exists at this point)
- Tab or click out of the field to trigger validation
- See that the validation errors on template name and memory disappear
