### PR TITLE
Entrypoint override is lost when using inheritFrom

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -651,6 +651,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         boolean privileged = this.privileged ? this.privileged : parent.getPrivileged();
         String containerUser = isNullOrEmpty(this.containerUser) ? parent.getContainerUser() : this.containerUser;
         String logDriver = isNullOrEmpty(this.logDriver) ? parent.getLogDriver() : this.logDriver;
+        String entrypoint = isNullOrEmpty(this.entrypoint) ? parent.getEntrypoint() : this.entrypoint;
 
         // TODO probably merge lists with parent instead of overriding them
         List<LogDriverOption> logDriverOptions = isEmpty(this.logDriverOptions) ? parent.getLogDriverOptions() : this.logDriverOptions;


### PR DESCRIPTION
If you setup a parent template with entrypoint = /bin/bash and a second template with inheritFrom = <LABEL_OF_PARENT> with no entrypoint, the second template has an empty entrypoint.
So parent entrypoint is lost.
The downside is that is you want to clear the entrypoint, you can't.
But you actually can't clear any parent option for now, only the entrypoint has a different behavior.