### PR TITLE
Add propagateTags option to RunTask API

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -414,7 +414,8 @@ public class ECSService {
                                 .withEnvironment(envNodeName)
                                 .withEnvironment(envNodeSecret)))
                 .withPlacementStrategy(template.getPlacementStrategyEntries())
-                .withCluster(clusterArn);
+                .withCluster(clusterArn)
+                .withPropagateTags(PropagateTags.TASK_DEFINITION);
 
         if (template.getLaunchType() != null && template.getLaunchType().equals("FARGATE")) {
             req.withPlatformVersion(template.getPlatformVersion());


### PR DESCRIPTION
I'd like to set tags to ECS task for cost analysis purpose. While
there's a few ways to set tags, the simplest way for amazon-ecs plugin
is to propagate task definition's tags to corresponding ECS tasks.

- https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html