### PR TITLE
Add assumed role option

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,14 @@ To run locally, execute the following command and open the browser [http://local
   mvn -e hpi:run
 ```
 
-### Debugging The plugin in an editor:
+### Debugging the plugin in an editor
+
+#### IntelliJ IDEA
+
+In the Maven dialog right click `hpi:run` and select `Debug`. 
+The IDE will stop at any breakpoints you have set inside the plugin.
+
+#### Other
 
 the
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -81,6 +81,7 @@ public class ECSCloud extends Cloud {
     private final String credentialsId;
     private final String cluster;
     private String regionName;
+    private String assumedRoleARN;
     @CheckForNull
     private String tunnel;
     private String jenkinsUrl;
@@ -155,9 +156,18 @@ public class ECSCloud extends Cloud {
         return regionName;
     }
 
+    public String getAssumedRoleARN() {
+        return assumedRoleARN;
+    }
+
     @DataBoundSetter
     public void setRegionName(String regionName) {
         this.regionName = regionName;
+    }
+
+    @DataBoundSetter
+    public void setAssumedRoleARN(String assumedRoleARN) {
+        this.assumedRoleARN = assumedRoleARN;
     }
 
     public String getTunnel() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -81,7 +81,7 @@ public class ECSCloud extends Cloud {
     private final String credentialsId;
     private final String cluster;
     private String regionName;
-    private String assumedRoleARN;
+    private String assumedRoleArn;
     @CheckForNull
     private String tunnel;
     private String jenkinsUrl;
@@ -96,9 +96,10 @@ public class ECSCloud extends Cloud {
     private int maxMemoryReservation;
 
     @DataBoundConstructor
-    public ECSCloud(String name, @Nonnull String credentialsId, String cluster) {
+    public ECSCloud(String name, @Nonnull String credentialsId, String assumedRoleArn, String cluster) {
         super(name);
         this.credentialsId = credentialsId;
+        this.assumedRoleArn = assumedRoleArn;
         this.cluster = cluster;
     }
 
@@ -106,6 +107,7 @@ public class ECSCloud extends Cloud {
         super(name);
         this.cluster = cluster;
         this.credentialsId = null;
+        this.assumedRoleArn = null;
         this.ecsService = ecsService;
     }
 
@@ -117,7 +119,7 @@ public class ECSCloud extends Cloud {
 
     synchronized ECSService getEcsService() {
         if (ecsService == null) {
-            ecsService = new ECSService(credentialsId, regionName);
+            ecsService = new ECSService(credentialsId, assumedRoleArn, regionName);
         }
         return ecsService;
     }
@@ -156,8 +158,8 @@ public class ECSCloud extends Cloud {
         return regionName;
     }
 
-    public String getAssumedRoleARN() {
-        return assumedRoleARN;
+    public String getAssumedRoleArn() {
+        return assumedRoleArn;
     }
 
     @DataBoundSetter
@@ -166,8 +168,8 @@ public class ECSCloud extends Cloud {
     }
 
     @DataBoundSetter
-    public void setAssumedRoleARN(String assumedRoleARN) {
-        this.assumedRoleARN = assumedRoleARN;
+    public void setAssumedRoleArn(String assumedRoleArn) {
+        this.assumedRoleArn = assumedRoleArn;
     }
 
     public String getTunnel() {
@@ -465,8 +467,8 @@ public class ECSCloud extends Cloud {
             return options;
         }
 
-        public ListBoxModel doFillClusterItems(@QueryParameter String credentialsId, @QueryParameter String regionName) {
-            ECSService ecsService = new ECSService(credentialsId, regionName);
+        public ListBoxModel doFillClusterItems(@QueryParameter String credentialsId, @QueryParameter String assumedRoleArn, @QueryParameter String regionName) {
+            ECSService ecsService = new ECSService(credentialsId, assumedRoleArn, regionName);
             try {
                 final AmazonECS client = ecsService.getAmazonECSClient();
                 final List<String> allClusterArns = new ArrayList<String>();

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -41,6 +41,10 @@
     <f:select />
   </f:entry>
 
+  <f:entry field="assumedRoleARN" title="${%Assumed Role ARN}">
+    <f:textbox />
+  </f:entry>
+
   <f:advanced>
     <f:entry field="allowedOverrides" title="${%Allowed declarative settings}" description="Settings allowed to be used in the declarative pipeline. Use all for unrestricted use. Always include label, otherwise no agent can be defined. The default is none for security reasons, which fully disables the use of declarative settings.">
       <f:textbox />

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -33,16 +33,16 @@
     <c:select />
   </f:entry>
 
+  <f:entry field="assumedRoleArn" title="${%Assumed Role ARN}">
+    <f:textbox />
+  </f:entry>
+
   <f:entry field="regionName" title="${%Amazon ECS Region Name}" description="AWS regionName for ECS. If not specified, use us-east-1.">
     <f:select />
   </f:entry>
 
   <f:entry field="cluster" title="${%ECS Cluster}">
     <f:select />
-  </f:entry>
-
-  <f:entry field="assumedRoleARN" title="${%Assumed Role ARN}">
-    <f:textbox />
   </f:entry>
 
   <f:advanced>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/help-assumedRoleARN.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/help-assumedRoleARN.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+ARN of IAM role assumed when making AWS API calls to create ECS agents. Use  for scenarios such as creating
+ECS agents in a different AWS account.

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -35,7 +35,7 @@ public class ECSCloudTest {
         List<ECSTaskTemplate> templates = new ArrayList<>();
         templates.add(getTaskTemplate("my-template","label"));
 
-        ECSCloud sut = new ECSCloud("mycloud", "", "mycluster");
+        ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setTemplates(templates);
         sut.setRegionName("eu-west-1");
         sut.setJenkinsUrl("http://jenkins.local");
@@ -51,7 +51,7 @@ public class ECSCloudTest {
 
         List<ECSTaskTemplate> templates = new ArrayList<>();
 
-        ECSCloud sut = new ECSCloud("mycloud", "", "mycluster");
+        ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setTemplates(templates);
         sut.setRegionName("eu-west-1");
         sut.setJenkinsUrl("http://jenkins.local");
@@ -101,7 +101,7 @@ public class ECSCloudTest {
 
     @Test
     public void provisionByLabelInheritFromUsingListOfLabels() throws Exception {
-        ECSCloud            cloud    = new ECSCloud("mycloud", "", "mycluster");
+        ECSCloud            cloud    = new ECSCloud("mycloud", "", "", "mycluster");
         ECSTaskTemplate expected = getTaskTemplate("somename","label1 label2 label3");
 
         List<ECSTaskTemplate> currentTemplates = cloud.getTemplates();
@@ -123,7 +123,7 @@ public class ECSCloudTest {
     @Test
     public void isAllowedOverride_empty_returnsFalse() throws Exception {
 
-        ECSCloud sut = new ECSCloud("mycloud", "", "mycluster");
+        ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
 
         Assert.assertFalse(sut.isAllowedOverride("label"));
     }
@@ -131,7 +131,7 @@ public class ECSCloudTest {
     @Test
     public void isAllowedOverride_label_returnsTrue() throws Exception {
 
-        ECSCloud sut = new ECSCloud("mycloud", "", "mycluster");
+        ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setAllowedOverrides("label");
 
         Assert.assertTrue(sut.isAllowedOverride("label"));


### PR DESCRIPTION
New UI option to provide an `Assumed Role ARN`

> ARN of IAM role assumed when making AWS API calls to create ECS agents. Use for scenarios such as creating ECS agents in a different AWS account.

I have verified this works, by assuming a role in another AWS account and provisioning a Jenkins agent.

Let me know if I missed anything. Thanks :)

resolves #220 
resolves #103 