### PR TITLE
Fix list formatting issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ One or several ECS agent templates can be defined for the Amazon EC2 Container S
 -   `Template name` is used (prefixed with the cloud's name) for the task definition in ECS.
 -   `Label`: agent labels used in conjunction with the job level configuration "Restrict where the project can be run / Label expression". ECS agent label could identify the Docker image used for the agent (e.g. `docker` for the jenkinsci/inbound-agent).
 -   `Docker image`: identifier of the Docker image to use to create the agents
-    `Filesystem root`: working directory used by Jenkins (e.g. `/home/jenkins/`).
-    `Memory`: number of MiB of memory reserved for the container. If your container attempts to exceed the memory allocated here, the container is killed.
+-   `Filesystem root`: working directory used by Jenkins (e.g. `/home/jenkins/`).
+-   `Memory`: number of MiB of memory reserved for the container. If your container attempts to exceed the memory allocated here, the container is killed.
 -   The number of `cpu units` to reserve for the container. A container instance has 1,024 cpu units for every CPU core.
     Advanced Configuration
 


### PR DESCRIPTION
# What does this do?

This commit fixes a formatting issue with the parameters in `ECS Agent Templates` list.

# Why are we doing this?

This formatting change makes the README.md easier to read.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
