### PR TITLE
Support Fargate EphemeralStorageSize

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -324,6 +324,11 @@ public class ECSService extends BaseAWSService {
                         .withNetworkMode(NetworkMode.Awsvpc.toString())
                         .withMemory(String.valueOf(template.getMemoryConstraint()))
                         .withCpu(String.valueOf(template.getCpu()));
+                if (template.getEphemeralStorageSizeInGiB() != null && template.getEphemeralStorageSizeInGiB() > 0) {
+                    request.withEphemeralStorage(new EphemeralStorage()
+                            .withSizeInGiB(template.getEphemeralStorageSizeInGiB())
+                    );
+                }
             }
 
             final RegisterTaskDefinitionResult result = client.registerTaskDefinition(request);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -86,6 +86,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -171,6 +172,13 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
      * @see ContainerDefinition#withCpu(Integer)
      */
     private final int cpu;
+
+    /**
+     * The ephemeral storage settings to use for tasks run with the task definition.
+     *
+     * @see com.amazonaws.services.ecs.model.TaskDefinition#withEphemeralStorage
+     */
+    private Integer ephemeralStorageSizeInGiB;
 
     /**
      * Sets the size of Share Memory (in MiB) using the
@@ -367,6 +375,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                            int memory,
                            int memoryReservation,
                            int cpu,
+                           @Nullable Integer ephemeralStorageSizeInGiB,
                            @Nullable String subnets,
                            @Nullable String securityGroups,
                            boolean assignPublicIp,
@@ -409,6 +418,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         this.memory = memory;
         this.memoryReservation = memoryReservation;
         this.cpu = cpu;
+        this.ephemeralStorageSizeInGiB = ephemeralStorageSizeInGiB;
         this.launchType = launchType;
         this.operatingSystemFamily = operatingSystemFamily;
         this.cpuArchitecture = cpuArchitecture;
@@ -562,6 +572,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     }
 
     public int getSharedMemorySize() { return sharedMemorySize; }
+
+    public Integer getEphemeralStorageSizeInGiB() {
+        return ephemeralStorageSizeInGiB;
+    }
 
     public String getSubnets() {
         return subnets;
@@ -763,6 +777,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         int memory = this.memory == 0 ? parent.getMemory() : this.memory;
         int memoryReservation = this.memoryReservation == 0 ? parent.getMemoryReservation() : this.memoryReservation;
         int cpu = this.cpu == 0 ? parent.getCpu() : this.cpu;
+        Integer ephemeralStorageSizeInGiB = this.ephemeralStorageSizeInGiB == null ? parent.getEphemeralStorageSizeInGiB() : this.ephemeralStorageSizeInGiB;
         int sharedMemorySize = this.sharedMemorySize == 0 ? parent.getSharedMemorySize() : this.sharedMemorySize;
         String subnets = isNullOrEmpty(this.subnets) ? parent.getSubnets() : this.subnets;
         String securityGroups = isNullOrEmpty(this.securityGroups) ? parent.getSecurityGroups() : this.securityGroups;
@@ -809,6 +824,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                                                        memory,
                                                        memoryReservation,
                                                        cpu,
+                                                       ephemeralStorageSizeInGiB,
                                                        subnets,
                                                        securityGroups,
                                                        assignPublicIp,
@@ -1464,6 +1480,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         if (cpu != that.cpu) {
             return false;
         }
+        if (!Objects.equals(ephemeralStorageSizeInGiB, that.ephemeralStorageSizeInGiB)) {
+            return false;
+        }
         if (sharedMemorySize != that.sharedMemorySize) {
             return false;
         }
@@ -1579,6 +1598,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         result = 31 * result + memory;
         result = 31 * result + memoryReservation;
         result = 31 * result + cpu;
+        result = 31 * result + (ephemeralStorageSizeInGiB != null ? ephemeralStorageSizeInGiB : 0);
         result = 31 * result + sharedMemorySize;
         result = 31 * result + (platformVersion != null ? platformVersion.hashCode() : 0);
         result = 31 * result + (subnets != null ? subnets.hashCode() : 0);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
@@ -62,6 +62,7 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
     private int memory;
     private int memoryReservation;
     private int cpu;
+    private Integer ephemeralStorageSizeInGiB;
     private int sharedMemorySize;
     private String subnets;
     private String securityGroups;
@@ -225,6 +226,15 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
 
     public int getCpu() {
         return cpu;
+    }
+
+    @DataBoundSetter
+    public void setEphemeralStorageSizeInGiB(Integer ephemeralStorageSizeInGiB) {
+        this.ephemeralStorageSizeInGiB = ephemeralStorageSizeInGiB;
+    }
+
+    public Integer getEphemeralStorageSizeInGiB() {
+        return ephemeralStorageSizeInGiB;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -70,6 +70,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
                                           step.getMemory(),
                                           step.getMemoryReservation(),
                                           step.getCpu(),
+                                          step.getEphemeralStorageSizeInGiB(),
                                           step.getSubnets(),
                                           step.getSecurityGroups(),
                                           step.getAssignPublicIp(),

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -91,6 +91,9 @@
   <f:entry title="${%CPU units}" field="cpu">
     <f:textbox default="1"/>
   </f:entry>
+  <f:entry title="${%Ephemeral Storage (GiB)}" field="ephemeralStorageSizeInGiB">
+    <f:textbox />
+  </f:entry>
   <f:entry title="${%Subnets}" field="subnets" description="List of subnets, separated by comma, only needed when using fargate or awsvpc network mode">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-ephemeralStorageSizeInGiB.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-ephemeralStorageSizeInGiB.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+The amount of ephemeral storage in GB to allocate for the task. This parameter is used to expand the total amount of
+ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate.

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -113,7 +113,7 @@ public class ECSCloudTest {
     public void removeJunkTemplateProducesNoError() throws Exception {
         ECSService ecsService = mock(ECSService.class);
         when(ecsService.findTaskDefinition(anyString())).thenReturn(null);
-        ECSCloud cloud = new ECSCloud("mycloud", "mycluster",ecsService);
+        ECSCloud cloud = new ECSCloud("mycloud", "mycluster", ecsService);
         cloud.setRegionName("us-east-1");
         cloud.removeDynamicTemplate(getTaskTemplate(Math.random() + "", "label1, label2, label3"));
     }
@@ -199,6 +199,7 @@ public class ECSCloudTest {
                 0,
                 0,
                 0,
+                null,
                 null,
                 null,
                 false,

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -94,6 +94,7 @@ public class ECSSlaveTest {
             0,
             null,
             null,
+            null,
             false,
             false,
             null,

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
@@ -11,7 +11,7 @@ public class ECSTaskTemplateTest {
         return new ECSTaskTemplate(
                 "parent-name", "parent-label",
                 null, null, "parent-image", "parent-repository-credentials", "FARGATE", "LINUX", "X86_64",false, null, "parent-network-mode", "parent-remoteFSRoot",
-                false, null, 0, 0, 0, null, null, false, false,
+                false, null, 0, 0, 0, null, null, null, false, false,
                 "parent-containerUser", "parent-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
     }
 
@@ -19,7 +19,7 @@ public class ECSTaskTemplateTest {
         return new ECSTaskTemplate(
                 "child-name", "child-label",
                 null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
-                false, null, 0, 0, 0, null, null, false, false,
+                false, null, 0, 0, 0, null, null, null, false, false,
                 "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, parent, 0, false);
     }
 
@@ -32,7 +32,7 @@ public class ECSTaskTemplateTest {
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
-            false, null, 0, 0, 0, null, null, false, false,
+            false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
 
 
@@ -49,7 +49,7 @@ public class ECSTaskTemplateTest {
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
-            false, null, 0, 0, 0, null, null, false, false,
+            false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
 
         ECSTaskTemplate result = child.merge(parent);
@@ -65,7 +65,7 @@ public class ECSTaskTemplateTest {
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
             null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
-            false, null, 0, 0, 0, null, null, false, false,
+            false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
 
         ECSTaskTemplate result = child.merge(null);
@@ -83,7 +83,7 @@ public class ECSTaskTemplateTest {
         ECSTaskTemplate expected = new ECSTaskTemplate(
                 "child-name", "child-label",
                 null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
-                false, null, 0, 0, 0, null, null, false, false,
+                false, null, 0, 0, 0, null, null, null, false, false,
                 "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
 
         //Child entrypoint should equal to parent by default

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
@@ -82,6 +82,7 @@ public class ECSTaskTemplateStepExecutionTest {
                 r.nextInt(123),
                 r.nextInt(456),
                 r.nextInt(1024),
+                r.nextInt(200),
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
                 r.nextBoolean(),
@@ -120,6 +121,7 @@ public class ECSTaskTemplateStepExecutionTest {
         step.setMemory(expected.getMemory());
         step.setMemoryReservation(expected.getMemoryReservation());
         step.setCpu(expected.getCpu());
+        step.setEphemeralStorageSizeInGiB(expected.getEphemeralStorageSizeInGiB());
         step.setSubnets(expected.getSubnets());
         step.setSecurityGroups(expected.getSecurityGroups());
         step.setAssignPublicIp(expected.getAssignPublicIp());
@@ -168,6 +170,7 @@ public class ECSTaskTemplateStepExecutionTest {
                 0,
                 0,
                 0,
+                null,
                 null,
                 null,
                 false,


### PR DESCRIPTION
Enable EphemeralStorageSize allows you to increase the size of the root
disk up to 100GB.  Only support for Fargate 1.4.0 and above.
As this requires AWS java SDK version 2.11.1008 some extra depdencies
needed to be updated.

