### PR TITLE
Add support for KernelCapabilities

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -261,6 +261,10 @@ public class ECSService {
         if (template.getContainerUser() != null)
             def.withUser(template.getContainerUser());
 
+        if (template.getKernelCapabilities() != null) {
+            def.withLinuxParameters(new LinuxParameters().withCapabilities(new KernelCapabilities().withAdd(Arrays.asList(template.getKernelCapabilities().split(",")))));
+        }
+
         if (template.getRepositoryCredentials() != null)
             def.withRepositoryCredentials(new RepositoryCredentials().withCredentialsParameter(template.getRepositoryCredentials()));
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -273,10 +273,16 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     private final String platformVersion;
 
     /**
-     * User for conatiner
+     * User for container
      */
     @Nullable
     private String containerUser;
+
+    /**
+     * List of kernel capabilities to be added
+     */
+    @Nullable
+    private String kernelCapabilities;
 
     private List<EnvironmentEntry> environments;
     private List<ExtraHostEntry> extraHosts;
@@ -329,6 +335,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                            boolean assignPublicIp,
                            boolean privileged,
                            @Nullable String containerUser,
+                           @Nullable String kernelCapabilities,
                            @Nullable List<LogDriverOption> logDriverOptions,
                            @Nullable List<EnvironmentEntry> environments,
                            @Nullable List<ExtraHostEntry> extraHosts,
@@ -372,6 +379,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         this.assignPublicIp = assignPublicIp;
         this.privileged = privileged;
         this.containerUser = StringUtils.trimToNull(containerUser);
+        this.kernelCapabilities = StringUtils.trimToNull(kernelCapabilities);
         this.logDriverOptions = logDriverOptions;
         this.environments = environments;
         this.extraHosts = extraHosts;
@@ -418,6 +426,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     @DataBoundSetter
     public void setContainerUser(String containerUser) {
         this.containerUser = StringUtils.trimToNull(containerUser);
+    }
+
+    @DataBoundSetter
+    public void setKernelCapabilities(String kernelCapabilities) {
+        this.kernelCapabilities = StringUtils.trimToNull(kernelCapabilities);
     }
 
     @DataBoundSetter
@@ -549,6 +562,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
 
     public String getContainerUser() {
         return containerUser;
+    }
+
+    public String getKernelCapabilities() {
+        return kernelCapabilities;
     }
 
     public String getLaunchType() {
@@ -685,6 +702,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         // Bug potential here. If I intenionally set it false in the child, then it will be ignored and take the parent. Need null to mean 'unset'
         boolean privileged = this.privileged ? this.privileged : parent.getPrivileged();
         String containerUser = isNullOrEmpty(this.containerUser) ? parent.getContainerUser() : this.containerUser;
+        String kernelCapabilities = isNullOrEmpty(this.kernelCapabilities) ? parent.getKernelCapabilities() : this.kernelCapabilities;
         String logDriver = isNullOrEmpty(this.logDriver) ? parent.getLogDriver() : this.logDriver;
         String entrypoint = isNullOrEmpty(this.entrypoint) ? parent.getEntrypoint() : this.entrypoint;
 
@@ -721,6 +739,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                                                        assignPublicIp,
                                                        privileged,
                                                        containerUser,
+                                                       kernelCapabilities,
                                                        logDriverOptions,
                                                        environments,
                                                        extraHosts,
@@ -1259,6 +1278,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         if (containerUser != null ? !containerUser.equals(that.containerUser) : that.containerUser != null) {
             return false;
         }
+        if (kernelCapabilities != null ? !kernelCapabilities.equals(that.kernelCapabilities) : that.kernelCapabilities != null) {
+            return false;
+        }
         if (environments != null ? !environments.equals(that.environments) : that.environments != null) {
             return false;
         }
@@ -1309,6 +1331,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         result = 31 * result + (privileged ? 1 : 0);
         result = 31 * result + (uniqueRemoteFSRoot ? 1 : 0);
         result = 31 * result + (containerUser != null ? containerUser.hashCode() : 0);
+        result = 31 * result + (kernelCapabilities != null ? kernelCapabilities.hashCode() : 0);
         result = 31 * result + (environments != null ? environments.hashCode() : 0);
         result = 31 * result + (extraHosts != null ? extraHosts.hashCode() : 0);
         result = 31 * result + (portMappings != null ? portMappings.hashCode() : 0);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
@@ -42,6 +42,7 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
     private boolean assignPublicIp;
     private boolean privileged;
     private String containerUser;
+    private String kernelCapabilities;
     private String executionRole;
     private String taskrole;
     private String inheritFrom;
@@ -228,6 +229,16 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
         overrides.add("containerUser");
     }
 
+    public String getKernelCapabilities() {
+        return kernelCapabilities;
+    }
+
+    @DataBoundSetter
+    public void setKernelCapabilities(String kernelCapabilities) {
+        this.kernelCapabilities = kernelCapabilities;
+        overrides.add("kernelCapabilities");
+    }
+
     public String getExecutionRole() {
         return executionRole;
     }
@@ -380,6 +391,10 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
 
         if (!StringUtils.isEmpty(containerUser)) {
             argMap.put("containerUser", containerUser);
+        }
+
+        if (!StringUtils.isEmpty(kernelCapabilities)) {
+            argMap.put("kernelCapabilities", kernelCapabilities);
         }
 
         if (!StringUtils.isEmpty(executionRole)) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
@@ -65,6 +65,7 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
     private boolean assignPublicIp;
     private boolean privileged;
     private String containerUser;
+    private String kernelCapabilities;
     private String executionRole;
     private String taskrole;
     private String inheritFrom;
@@ -263,6 +264,15 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
 
     public String getContainerUser() {
         return containerUser;
+    }
+
+    @DataBoundSetter
+    public void setKernelCapabilities(String kernelCapabilities) {
+        this.kernelCapabilities = kernelCapabilities;
+    }
+
+    public String getKernelCapabilities() {
+        return kernelCapabilities;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -75,6 +75,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
                                           step.getAssignPublicIp(),
                                           step.getPrivileged(),
                                           step.getContainerUser(),
+                                          step.getKernelCapabilities(),
                                           step.getLogDriverOptions(),
                                           step.getEnvironments(),
                                           step.getExtraHosts(),

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -122,6 +122,9 @@
     <f:entry title="${%ContainerUser}" field="containerUser">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Add Kernel Capabilities}" field="kernelCapabilities" description="List of kernel capabilities to be added, separated by comma">
+      <f:textbox />
+    </f:entry>
     <f:entry title="${%Logging Driver}" field="logDriver">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-kernelCapabilities.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-kernelCapabilities.html
@@ -1,0 +1,43 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+<p>
+    The Linux capabilities for the container to be added to the default configuration provided by Docker. 
+    This parameter maps to CapAdd in the Create a container section of the Docker Remote API and the --cap-add option to docker run.
+</p>
+<p>
+    Valid values: "ALL" | "AUDIT_CONTROL" | "AUDIT_READ" | "AUDIT_WRITE" | "BLOCK_SUSPEND" | "CHOWN" | "DAC_OVERRIDE" | 
+    "DAC_READ_SEARCH" | "FOWNER" | "FSETID" | "IPC_LOCK" | "IPC_OWNER" | "KILL" | "LEASE" | "LINUX_IMMUTABLE" | "MAC_ADMIN" | 
+    "MAC_OVERRIDE" | "MKNOD" | "NET_ADMIN" | "NET_BIND_SERVICE" | "NET_BROADCAST" | "NET_RAW" | "SETFCAP" | "SETGID" | 
+    "SETPCAP" | "SETUID" | "SYS_ADMIN" | "SYS_BOOT" | "SYS_CHROOT" | "SYS_MODULE" | "SYS_NICE" | "SYS_PACCT" | "SYS_PTRACE" | 
+    "SYS_RAWIO" | "SYS_RESOURCE" | "SYS_TIME" | "SYS_TTY_CONFIG" | "SYSLOG" | "WAKE_ALARM"
+</p>
+<p>
+    Tasks launched on AWS Fargate only support adding the SYS_PTRACE kernel capability.
+</p>
+<p>
+    See <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_linuxparameters">Container Definition Linux Parameters</a> for
+    more details about task kernel capabilities.
+</p>

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -173,7 +173,6 @@ public class ECSCloudTest {
                 null,
                 null,
                 null,
-                0,
-                false);
+                0);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -173,6 +173,7 @@ public class ECSCloudTest {
                 null,
                 null,
                 null,
-                0);
+                0,
+                false);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -172,6 +172,7 @@ public class ECSCloudTest {
                 null,
                 null,
                 null,
+                null,
                 0);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -104,6 +104,7 @@ public class ECSSlaveTest {
             null,
             null,
             null,
+            null,
             0);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
@@ -12,7 +12,7 @@ public class ECSTaskTemplateTest {
                 "parent-name", "parent-label",
                 null, null, "parent-image", "parent-repository-credentials", "FARGATE", false, null, "parent-network-mode", "parent-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, false, false,
-                "parent-containerUser", null, null, null, null, null, null, null, null, null, 0);
+                "parent-containerUser", "parent-kernelCapabilities", null, null, null, null, null, null, null, null, null, 0);
     }
 
     ECSTaskTemplate getChild(String parent) {
@@ -20,7 +20,7 @@ public class ECSTaskTemplateTest {
                 "child-name", "child-label",
                 null, null, "child-image", "child-repository-credentials", "EC2", false, null, "child-network-mode", "child-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, false, false,
-                "child-containerUser", null, null, null, null, null, null, null, null, parent, 0);
+                "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, parent, 0);
     }
 
     @Test
@@ -33,7 +33,7 @@ public class ECSTaskTemplateTest {
             "child-name", "child-label",
             null, null, "child-image", "child-repository-credentials", "EC2", false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, null, null, null, 0);
+            "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, 0);
 
 
         ECSTaskTemplate result = child.merge(parent);
@@ -50,7 +50,7 @@ public class ECSTaskTemplateTest {
             "child-name", "child-label",
             null, null, "child-image", "child-repository-credentials", "EC2", false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, null, null, null, 0);
+            "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, 0);
 
         ECSTaskTemplate result = child.merge(parent);
 
@@ -66,7 +66,7 @@ public class ECSTaskTemplateTest {
             "child-name", "child-label",
             null, null, "child-image", "child-repository-credentials", "EC2", false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, false, false,
-            "child-containerUser", null, null, null, null, null, null, null, null, null, 0);
+            "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, 0);
 
         ECSTaskTemplate result = child.merge(null);
 
@@ -84,7 +84,7 @@ public class ECSTaskTemplateTest {
                 "child-name", "child-label",
                 null, null, "child-image", "child-repository-credentials", "EC2", false, null, "child-network-mode", "child-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, false, false,
-                "child-containerUser", null, null, null, null, null, null, null, null, null, 0);
+                "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, 0);
 
         //Child entrypoint should equal to parent by default
         parent.setEntrypoint(entrypoint);

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
@@ -90,6 +90,7 @@ public class ECSTaskTemplateStepExecutionTest {
                 null,
                 null,
                 null,
+                null,
                 UUID.randomUUID().toString(),
                 null,
                 "override-task-role",
@@ -118,6 +119,7 @@ public class ECSTaskTemplateStepExecutionTest {
         step.setAssignPublicIp(expected.getAssignPublicIp());
         step.setPrivileged(expected.getPrivileged());
         step.setContainerUser(expected.getContainerUser());
+        step.setKernelCapabilities(expected.getKernelCapabilities());
         step.setLogDriverOptions(expected.getLogDriverOptions());
         step.setEnvironments(expected.getEnvironments());
         step.setExtraHosts(expected.getExtraHosts());
@@ -161,6 +163,7 @@ public class ECSTaskTemplateStepExecutionTest {
                 null,
                 false,
                 false,
+                null,
                 null,
                 null,
                 null,


### PR DESCRIPTION
This commit adds option to add kernel capabilities for ECS task definition.  Relevant GutHub issue is [#241](https://github.com/jenkinsci/amazon-ecs-plugin/issues/241).

It's described [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_linuxparameters).

Currently, Fargate supports just SYS_PTRACE kernel capability, EC2 ECS supports everything on the link above.

I have tested this with Fargate, and it works fine, haven't tested with EC2 ECS.

NOTE: This adds option to add kernel capabilities, I haven't implemented option to drop capabilities, but should be easy to add, though I think it's rarely being used.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
