### PR TITLE
Added ability to define number of executors on agents

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -95,6 +95,7 @@ public class ECSCloud extends Cloud {
     private int maxMemory;
     private int maxMemoryReservation;
     private int maxAgents = DescriptorImpl.DEFAULT_MAXIMUM_AGENTS;
+    private int numExecutors;
 
     @DataBoundConstructor
     public ECSCloud(String name, @Nonnull String credentialsId, String assumedRoleArn, String cluster) {
@@ -282,7 +283,7 @@ public class ECSCloud extends Cloud {
                                 Computer.threadPoolForRemoting.submit(
                                         new ProvisioningCallback(merged, agentName)
                                 ),
-                                1
+                                numExecutors
                         )
                 );
             }
@@ -356,6 +357,15 @@ public class ECSCloud extends Cloud {
     @DataBoundSetter
     public void setMaxCpu(int maxCpu) {
         this.maxCpu = maxCpu;
+    }
+
+    public int getNumExecutors() {
+        return numExecutors;
+    }
+
+    @DataBoundSetter
+    public void setNumExecutors(int numExecutors) {
+        this.numExecutors = numExecutors;
     }
 
     public int getMaxMemory() {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -67,6 +67,9 @@
     <f:entry field="jenkinsUrl" title="${%Alternative Jenkins URL}" description="If needed, the Jenkins URL can be overwritten with this property (e.g. to support other HTTP(S) endpoints due to reverse proxies or firewalling). By default the URL from the global Jenkins configuration is used.">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Number of executors per agent}" field="numExecutors">
+    <f:textbox default="1"/>
+  </f:entry>
     <f:entry field="slaveTimeoutInSeconds" title="${%ECS task creation timeout}" description="Timeout (in seconds) for ECS task to be created, useful if you use large docker agent image, because the host will take more time to pull the docker image">
       <f:textbox default="${descriptor.defaultSlaveTimeoutInSeconds}" />
     </f:entry>

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -36,6 +36,7 @@ public class ECSCloudTest {
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setTemplates(templates);
         sut.setRegionName("eu-west-1");
+        sut.setNumExecutors(1);
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
         sut.setRetentionTimeout(5);
@@ -52,6 +53,7 @@ public class ECSCloudTest {
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setTemplates(templates);
         sut.setRegionName("eu-west-1");
+        sut.setNumExecutors(1);
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
         sut.setRetentionTimeout(5);
@@ -147,6 +149,7 @@ public class ECSCloudTest {
         sut.setMaxAgents(3);
         sut.setTemplates(templates);
         sut.setRegionName("eu-west-1");
+        sut.setNumExecutors(1);
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
         sut.setRetentionTimeout(5);
@@ -167,6 +170,7 @@ public class ECSCloudTest {
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setTemplates(templates);
         sut.setRegionName("eu-west-1");
+        sut.setNumExecutors(1);
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
         sut.setRetentionTimeout(5);


### PR DESCRIPTION
Removing hardcoded number of executors per agent and adding ability for users to define this via the cloud configuration settings page.

- Updated ECS Cloud resource to enable users to define numExecutors value in cloud configuration settings. Defaults to 1 as per existing hardcoded value.
- Updated initiation of  NodeProvisioner.PlannedNode to pass in new numExecutors value instead of the previously hardcoded one.
- Pulled from [https://github.com/plumbuma/amazon-ecs-plugin/commit/3ebfefa5b4f1d2e249f147aca6257b83219282dd](https://github.com/plumbuma/amazon-ecs-plugin/commit/3ebfefa5b4f1d2e249f147aca6257b83219282dd)
- Feature request - [https://github.com/jenkinsci/amazon-ecs-plugin/issues/265](https://github.com/jenkinsci/amazon-ecs-plugin/issues/265)
 
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
