### PR TITLE
add agent container name property #266

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ ecsTaskTemplate(
     containerUser: 'ubuntu',
     remoteFSRoot: '/home/ubuntu',
     overrides: [],
+    agentContainerName: 'java',    
     taskDefinitionOverride: "arn:aws:redacted:redacted:task-definition/${env.task}"
 ) {
   node(dynamic_label) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -100,6 +100,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     @CheckForNull
     private final String label;
 
+    @CheckForNull
+    private final String agentContainerName;
+
     /**
      * Task Definition Override to use, instead of a Jenkins-managed Task definition. May be a family name or an ARN.
      */
@@ -349,6 +352,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     @DataBoundConstructor
     public ECSTaskTemplate(String templateName,
                            @Nullable String label,
+                           @Nullable String agentContainerName,
                            @Nullable String taskDefinitionOverride,
                            @Nullable String dynamicTaskDefinitionOverride,
                            String image,
@@ -388,6 +392,13 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         // if the user enters a task definition override, always prefer to use it, rather than the jenkins template.
         if (taskDefinitionOverride != null && !taskDefinitionOverride.trim().isEmpty()) {
             this.taskDefinitionOverride = taskDefinitionOverride.trim();
+
+            if (agentContainerName != null && !agentContainerName.trim().isEmpty()) {
+                this.agentContainerName = agentContainerName.trim();
+            } else {
+                this.agentContainerName = null;
+            }
+
             // Always set the template name to the empty string if we are using a task definition override,
             // since we don't want Jenkins to touch our definitions.
             this.templateName = "";
@@ -398,6 +409,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                     "jenkinsTask-" + UUID.randomUUID().toString() : templateName;
             // Make sure we don't have both a template name and a task definition override.
             this.taskDefinitionOverride = null;
+            // An agent container name doesn't make sense when there is only one container
+            // definition.
+            this.agentContainerName = null;
         }
 
         this.label = label;
@@ -518,6 +532,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
 
     public String getLabel() {
         return label;
+    }
+
+    public String getAgentContainerName() {
+        return agentContainerName;
     }
 
     public String getTaskDefinitionOverride() {
@@ -808,6 +826,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         }
         String templateName = isNullOrEmpty(this.templateName) ? parent.getTemplateName() : this.templateName;
         String label = isNullOrEmpty(this.label) ? parent.getLabel() : this.label;
+        String agentContainerName = isNullOrEmpty(this.agentContainerName) ? parent.getAgentContainerName() : this.agentContainerName;
         String taskDefinitionOverride = isNullOrEmpty(this.taskDefinitionOverride) ? parent.getTaskDefinitionOverride() : this.taskDefinitionOverride;
         String image = isNullOrEmpty(this.image) ? parent.getImage() : this.image;
         String repositoryCredentials = isNullOrEmpty(this.repositoryCredentials) ? parent.getRepositoryCredentials() : this.repositoryCredentials;
@@ -857,6 +876,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
 
         ECSTaskTemplate merged = new ECSTaskTemplate(templateName,
                                                        label,
+                                                       agentContainerName,
                                                        taskDefinitionOverride,
                                                        null,
                                                        image,
@@ -1552,6 +1572,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         if (label != null ? !label.equals(that.label) : that.label != null) {
             return false;
         }
+        if (agentContainerName != null ? !agentContainerName.equals(that.agentContainerName) : that.agentContainerName != null) {
+            return false;
+        }
         if (taskDefinitionOverride != null ? !taskDefinitionOverride.equals(that.taskDefinitionOverride) : that.taskDefinitionOverride != null) {
             return false;
         }
@@ -1644,6 +1667,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     public int hashCode() {
         int result = templateName.hashCode();
         result = 31 * result + (label != null ? label.hashCode() : 0);
+        result = 31 * result + (agentContainerName != null ? agentContainerName.hashCode() : 0);
         result = 31 * result + (taskDefinitionOverride != null ? taskDefinitionOverride.hashCode() : 0);
         result = 31 * result + (image != null ? image.hashCode() : 0);
         result = 31 * result + (remoteFSRoot != null ? remoteFSRoot.hashCode() : 0);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
@@ -30,6 +30,7 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
 
     private String label;
     private String cloud;
+    private String agentContainerName;
     private String taskDefinitionOverride;
     private String image;
     private String launchType;
@@ -82,6 +83,16 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
     public void setCloud(String cloud) {
         this.cloud = cloud;
         overrides.add("cloud");
+    }
+
+    public String getAgentContainerName() {
+        return agentContainerName;
+    }
+
+    @DataBoundSetter
+    public void setAgentContainerName(String agentContainerName) {
+        this.agentContainerName = agentContainerName;
+        overrides.add("agentContainerName");
     }
 
     public String getTaskDefinitionOverride() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
@@ -49,6 +49,7 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
     private final String label;
     private final String name;
     private String cloud = DEFAULT_CLOUD;
+    private String agentContainerName;
     private String taskDefinitionOverride;
     private String repositoryCredentials;
     private String image;
@@ -110,6 +111,15 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
 
     public String getCloud() {
         return cloud;
+    }
+
+    @DataBoundSetter
+    public void setAgentContainerName(String agentContainerName) {
+        this.agentContainerName = agentContainerName;
+    }
+
+    public String getAgentContainerName() {
+        return agentContainerName;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -54,6 +54,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
 
         newTemplate = new ECSTaskTemplate(name,
                                           step.getLabel(),
+                                          step.getAgentContainerName(),
                                           step.getTaskDefinitionOverride(),
                                           null,
                                           step.getImage(),

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -31,6 +31,9 @@
   <f:entry title="${%Template Name}" field="templateName" description="The name that will be appended to the ECS cluster name when creating task definitions. Cannot be used with a Task Definition Override.">
       <f:textbox />
     </f:entry>
+  <f:entry title="${%Agent Container Name}" field="agentContainerName" description="Name of the Jenkins agent container. This is value is only used when Task Definition Override is defined.">
+      <f:textbox />
+  </f:entry>
   <f:entry title="${%Task Definition Override}" field="taskDefinitionOverride" description="Externally-managed ECS task definition to use, instead of creating task definitions using the Template Name. This value takes precedence over all other container settings.">
       <f:textbox />
   </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep/config.jelly
@@ -37,6 +37,9 @@
   <f:entry title="${%Template Name}" field="templateName" description="The name that will be appended to the ECS cluster name when creating task definitions. Cannot be used with a Task Definition Override.">
     <f:textbox />
   </f:entry>
+  <f:entry title="${%Agent Container Name}" field="agentContainerName" description="Name of the Jenkins agent container. This is value is only used when Task Definition Override is defined.">
+    <f:textbox />
+  </f:entry>
   <f:entry title="${%Task Definition Override}" field="taskDefinitionOverride"
     help="/descriptor/com.cloudbees.jenkins.plugins.amazonecs.ECSTaskTemplate/help/externalTaskDefinition"
     description="Externally-managed ECS task definition to use, instead of creating task definitions using the Template Name. This value takes precedence over all other container settings.">

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -188,6 +188,7 @@ public class ECSCloudTest {
                 templateName,
                 label,
                 "",
+                "",
                 null,
                 "image",
                 "repositoryCredentials",

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -76,6 +76,7 @@ public class ECSSlaveTest {
         return new ECSTaskTemplate(
             "templateName",
             "label",
+            "agentContainerName",
             "taskDefinitionOverride",
             null,
             "image",

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
@@ -12,7 +12,7 @@ public class ECSTaskTemplateTest {
     ECSTaskTemplate getParent() {
         return new ECSTaskTemplate(
                 "parent-name", "parent-label",
-                null, null, "parent-image", "parent-repository-credentials", "FARGATE", "LINUX", "X86_64",false, null, "parent-network-mode", "parent-remoteFSRoot",
+                null, null, null, "parent-image", "parent-repository-credentials", "FARGATE", "LINUX", "X86_64",false, null, "parent-network-mode", "parent-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, null, false, false,
                 "parent-containerUser", "parent-kernelCapabilities", null, new ArrayList<>(), null, null, null, null, null, null, null, null, null, 0, false);
     }
@@ -20,7 +20,7 @@ public class ECSTaskTemplateTest {
     ECSTaskTemplate getChild(String parent) {
         return new ECSTaskTemplate(
                 "child-name", "child-label",
-                null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+                null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, null, false, false,
                 "child-containerUser", "child-kernelCapabilities", null, new ArrayList<>(), null, null, null, null, null, null, null, null, parent, 0, false);
     }
@@ -33,7 +33,7 @@ public class ECSTaskTemplateTest {
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
-            null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+            null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, new ArrayList<>(), null, null, null, null, null, null, null, null, null, 0, false);
 
@@ -50,7 +50,7 @@ public class ECSTaskTemplateTest {
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
-            null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+            null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, new ArrayList<>(), null, null, null, null, null, null, null, null, null, 0, false);
 
@@ -66,7 +66,7 @@ public class ECSTaskTemplateTest {
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
-            null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+            null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, new ArrayList<>(), null, null, null, null, null, null, null, null, null, 0, false);
 
@@ -84,7 +84,7 @@ public class ECSTaskTemplateTest {
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
                 "child-name", "child-label",
-                null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+                null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, null, false, false,
                 "child-containerUser", "child-kernelCapabilities", null, new ArrayList<>(), null, null, null, null, null, null, null, null, null, 0, false);
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
@@ -68,6 +68,7 @@ public class ECSTaskTemplateStepExecutionTest {
                 "template-name",
                 "child-label",
                 UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
                 null,
                 "image-override",
                 UUID.randomUUID().toString(),
@@ -114,6 +115,7 @@ public class ECSTaskTemplateStepExecutionTest {
         step.setLaunchType(expected.getLaunchType());
         step.setOperatingSystemFamily(expected.getOperatingSystemFamily());
         step.setCpuArchitecture(expected.getCpuArchitecture());
+        step.setAgentContainerName(expected.getAgentContainerName());
         step.setTaskDefinitionOverride(expected.getTaskDefinitionOverride());
         step.setRepositoryCredentials(expected.getRepositoryCredentials());
         step.setNetworkMode(expected.getNetworkMode());
@@ -156,6 +158,7 @@ public class ECSTaskTemplateStepExecutionTest {
         return new ECSTaskTemplate(
                 templateName,
                 label,
+                "",
                 "",
                 null,
                 "image",


### PR DESCRIPTION
Implement https://github.com/jenkinsci/amazon-ecs-plugin/issues/266

This exposes a new agentContainerName property on templates. This specifies the name of the container that will be used for the Jenkins agent.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
