### PR TITLE
Ensure maxAgents is respected when requesting additional agents.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -217,7 +217,7 @@ public class ECSCloud extends Cloud {
             return excessWorkload;
         }
         try {
-            int currentAgentCapacity = Math.subtractExact(Math.addExact(onlineExecutors, onlineExecutors), maxAgents);
+            int currentAgentCapacity = Math.subtractExact(Math.addExact(onlineExecutors, connectingExecutors), maxAgents);
         } catch (ArithmeticException e) {
             LOGGER.log(Level.WARNING, "Overflow encountered when calculating agent capacity.", e);
             // Where an overflow is detected the safest thing to do is probably return zero here so as not to compound

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -211,14 +211,13 @@ public class ECSCloud extends Cloud {
         return getTemplate(label) != null;
     }
 
-    public boolean isAtLimit(int onlineExecutors, int connectingExecutors) {
-       // maxAgents equals 0 indicates that we don't have restriction on number of nodes.
-        if (maxAgents != 0) {
-            if (onlineExecutors + connectingExecutors >= maxAgents ) {
-                return true;
-            }
+    public int getProvisioningCapacity(int excessWorkload, int onlineExecutors, int connectingExecutors) {
+        // When maxAgents is zero don't limit the number of agents available for provisioning.
+        if (maxAgents == 0) {
+            return excessWorkload;
         }
-        return false;
+        int currentAgentCapacity = (maxAgents - (onlineExecutors + connectingExecutors));
+        return Math.min(excessWorkload, currentAgentCapacity);
     }
 
     private ECSTaskTemplate getTemplate(Label label) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -216,6 +216,14 @@ public class ECSCloud extends Cloud {
         if (maxAgents == 0) {
             return excessWorkload;
         }
+        try {
+            int currentAgentCapacity = Math.subtractExact(Math.addExact(onlineExecutors, onlineExecutors), maxAgents);
+        } catch (ArithmeticException e) {
+            LOGGER.log(Level.WARNING, "Overflow encountered when calculating agent capacity.", e);
+            // Where an overflow is detected the safest thing to do is probably return zero here so as not to compound
+            // the problem.
+            return 0;
+        }
         int currentAgentCapacity = (maxAgents - (onlineExecutors + connectingExecutors));
         return Math.min(excessWorkload, currentAgentCapacity);
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -225,7 +225,9 @@ public class ECSCloud extends Cloud {
             return 0;
         }
         int currentAgentCapacity = (maxAgents - (onlineExecutors + connectingExecutors));
-        return Math.min(excessWorkload, currentAgentCapacity);
+        // Return the lowest value between excessWorkload and currentAgentCapacity, with zero being the minimum returned
+        // value.
+        return Math.max(0, Math.min(excessWorkload, currentAgentCapacity));
     }
 
     private ECSTaskTemplate getTemplate(Label label) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
@@ -55,14 +55,17 @@ public class ECSProvisioningStrategy extends NodeProvisioner.Strategy {
                 }
             }
 
+            int maxProvisioningCapacity = 0;
             if (c instanceof ECSCloud) {
                 Boolean isAtLimit = ((ECSCloud) c).isAtLimit(snap.getOnlineExecutors(), snap.getConnectingExecutors());
                 if ( isAtLimit ) {
                     return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED; //maxAgents provisioned
                 }
+                maxProvisioningCapacity = (((ECSCloud) c).getMaxAgents() - (snap.getOnlineExecutors() + snap.getConnectingExecutors()));
             }
 
-            Collection<NodeProvisioner.PlannedNode> additionalCapacities = c.provision(label, excessWorkload);
+            int requestAdditionalCapacities = maxProvisioningCapacity == 0 ? excessWorkload : Math.min(excessWorkload, maxProvisioningCapacity);
+            Collection<NodeProvisioner.PlannedNode> additionalCapacities = c.provision(label, requestAdditionalCapacities);
 
             // compat with what the default NodeProvisioner.Strategy does
             fireOnStarted(c, label, additionalCapacities);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
@@ -55,16 +55,14 @@ public class ECSProvisioningStrategy extends NodeProvisioner.Strategy {
                 }
             }
 
-            int maxProvisioningCapacity = 0;
+            int provisioningCapacity = 0;
             if (c instanceof ECSCloud) {
-                Boolean isAtLimit = ((ECSCloud) c).isAtLimit(snap.getOnlineExecutors(), snap.getConnectingExecutors());
-                if ( isAtLimit ) {
-                    return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED; //maxAgents provisioned
+                provisioningCapacity = ((ECSCloud) c).getProvisioningCapacity(excessWorkload, snap.getOnlineExecutors(), snap.getConnectingExecutors());
+                if (provisioningCapacity == 0) {
+                    return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
                 }
-                maxProvisioningCapacity = (((ECSCloud) c).getMaxAgents() - (snap.getOnlineExecutors() + snap.getConnectingExecutors()));
             }
-
-            int requestAdditionalCapacities = maxProvisioningCapacity == 0 ? excessWorkload : Math.min(excessWorkload, maxProvisioningCapacity);
+            int requestAdditionalCapacities = provisioningCapacity == 0 ? excessWorkload : provisioningCapacity;
             Collection<NodeProvisioner.PlannedNode> additionalCapacities = c.provision(label, requestAdditionalCapacities);
 
             // compat with what the default NodeProvisioner.Strategy does

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -219,6 +219,27 @@ public class ECSCloudTest {
         Assert.assertEquals(4, provisioningCapacity);
     }
 
+    @Test
+    public void getProvisioningCapacity_returnsZeroWhenOverflowEncountered () {
+        int onlineExecutors = Integer.MAX_VALUE;
+        int connectingExecutors = 1;
+        int excessWorkload = 1;
+
+        List<ECSTaskTemplate> templates = new ArrayList<>();
+        templates.add(getTaskTemplate("my-template","label"));
+
+        ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
+        sut.setMaxAgents(10);
+        sut.setTemplates(templates);
+        sut.setRegionName("eu-west-1");
+        sut.setJenkinsUrl("http://jenkins.local");
+        sut.setSlaveTimeoutInSeconds(5);
+        sut.setRetentionTimeout(5);
+
+        int provisioningCapacity = sut.getProvisioningCapacity(excessWorkload, onlineExecutors, connectingExecutors);
+        Assert.assertEquals(0, provisioningCapacity);
+    }
+
     private ECSTaskTemplate getTaskTemplate() {
         return getTaskTemplate(UUID.randomUUID().toString(),UUID.randomUUID().toString());
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -240,6 +240,27 @@ public class ECSCloudTest {
         Assert.assertEquals(0, provisioningCapacity);
     }
 
+    @Test
+    public void getProvisioningCapacity_returnsZeroWhenCurrentAgentsGreaterThanMaxAgents () {
+        int onlineExecutors = 5;
+        int connectingExecutors = 5;
+        int excessWorkload = 1;
+
+        List<ECSTaskTemplate> templates = new ArrayList<>();
+        templates.add(getTaskTemplate("my-template","label"));
+
+        ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
+        sut.setMaxAgents(1);
+        sut.setTemplates(templates);
+        sut.setRegionName("eu-west-1");
+        sut.setJenkinsUrl("http://jenkins.local");
+        sut.setSlaveTimeoutInSeconds(5);
+        sut.setRetentionTimeout(5);
+
+        int provisioningCapacity = sut.getProvisioningCapacity(excessWorkload, onlineExecutors, connectingExecutors);
+        Assert.assertEquals(0, provisioningCapacity);
+    }
+
     private ECSTaskTemplate getTaskTemplate() {
         return getTaskTemplate(UUID.randomUUID().toString(),UUID.randomUUID().toString());
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -136,44 +136,87 @@ public class ECSCloudTest {
     }
 
     @Test
-    public void isAtLimit_returnsTrue () {
-        int onlineExecutors = 6;
-        int connectingExecutors = 2;
+    public void getProvisioningCapacity_returnsZeroWhenMaxAgentsReached () {
+        int onlineExecutors = 4;
+        int connectingExecutors = 1;
+        int excessWorkload = 5;
 
         List<ECSTaskTemplate> templates = new ArrayList<>();
         templates.add(getTaskTemplate("my-template","label"));
 
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
-        sut.setMaxAgents(3);
+        sut.setMaxAgents(5);
         sut.setTemplates(templates);
         sut.setRegionName("eu-west-1");
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
         sut.setRetentionTimeout(5);
 
-        Boolean isAtLimit = sut.isAtLimit(onlineExecutors, connectingExecutors);
-
-        Assert.assertTrue(isAtLimit);
+        int provisioningCapacity = sut.getProvisioningCapacity(excessWorkload, onlineExecutors, connectingExecutors);
+        Assert.assertEquals(0, provisioningCapacity);
     }
 
     @Test
-    public void isAtLimit_returnsFalse () {
-        int onlineExecutors = 3;
-        int connectingExecutors = 0;
+    public void getProvisioningCapacity_returnsRemainingMaxAgentsWhenWorkloadExceedsAvailability () {
+        int onlineExecutors = 7;
+        int connectingExecutors = 4;
+        int excessWorkload = 8;
 
         List<ECSTaskTemplate> templates = new ArrayList<>();
         templates.add(getTaskTemplate("my-template","label"));
 
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
+        sut.setMaxAgents(14);
         sut.setTemplates(templates);
         sut.setRegionName("eu-west-1");
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
         sut.setRetentionTimeout(5);
 
-        Boolean isAtLimit = sut.isAtLimit(onlineExecutors, connectingExecutors);
+        int provisioningCapacity = sut.getProvisioningCapacity(excessWorkload, onlineExecutors, connectingExecutors);
+        Assert.assertEquals(3, provisioningCapacity);
+    }
 
-        Assert.assertFalse(isAtLimit);
+    @Test
+    public void getProvisioningCapacity_returnsExcessWorkloadWithoutMaxAgents () {
+        int onlineExecutors = 6;
+        int connectingExecutors = 2;
+        int excessWorkload = 10;
+
+        List<ECSTaskTemplate> templates = new ArrayList<>();
+        templates.add(getTaskTemplate("my-template","label"));
+
+        ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
+        sut.setMaxAgents(0);
+        sut.setTemplates(templates);
+        sut.setRegionName("eu-west-1");
+        sut.setJenkinsUrl("http://jenkins.local");
+        sut.setSlaveTimeoutInSeconds(5);
+        sut.setRetentionTimeout(5);
+
+        int provisioningCapacity = sut.getProvisioningCapacity(excessWorkload, onlineExecutors, connectingExecutors);
+        Assert.assertEquals(10, provisioningCapacity);
+    }
+
+    @Test
+    public void getProvisioningCapacity_returnsExcessWorkloadWhenWorkloadDoesNotExceedAvailability () {
+        int onlineExecutors = 3;
+        int connectingExecutors = 2;
+        int excessWorkload = 4;
+
+        List<ECSTaskTemplate> templates = new ArrayList<>();
+        templates.add(getTaskTemplate("my-template","label"));
+
+        ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
+        sut.setMaxAgents(10);
+        sut.setTemplates(templates);
+        sut.setRegionName("eu-west-1");
+        sut.setJenkinsUrl("http://jenkins.local");
+        sut.setSlaveTimeoutInSeconds(5);
+        sut.setRetentionTimeout(5);
+
+        int provisioningCapacity = sut.getProvisioningCapacity(excessWorkload, onlineExecutors, connectingExecutors);
+        Assert.assertEquals(4, provisioningCapacity);
     }
 
     private ECSTaskTemplate getTaskTemplate() {


### PR DESCRIPTION
This change aims to fix the issues reported on https://github.com/jenkinsci/amazon-ecs-plugin/issues/269. Essentially when requesting additional agents the `excessWorkload` value is passed regardless of the `maxAgents` limit. When triggering parallel jobs `excessWorkload` may in fact be higher than the number of available agents when `maxAgents` is set.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
