### PR TITLE
Add missing ecs:ListTagsForResource permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ TaskRole:
                             - "ecs:ListTaskDefinitions"
                             - "ecs:DescribeTaskDefinition"
                             - "ecs:DeregisterTaskDefinition"
+                            - "ecs:ListTagsForResource"
                         Effect: Allow
                         Resource: "*"
                       - Action:


### PR DESCRIPTION
The `ecs:ListTagsForResource` permission is required to run a Jenkins agent in ECS.

Here's a sample Jenkins error log when the permission is missing:

```
[ecs-cloud-ecs-8thbs]: Error in provisioning; agent=com.cloudbees.jenkins.plugins.amazonecs.ECSSlave[ecs-cloud-ecs-8thbs]
com.amazonaws.services.ecs.model.AccessDeniedException: User: arn:aws:sts::299404798587:assumed-role/jenkins-role/0bb4884c56ce41ffb16659f56041491f is not authorized to perform: ecs:ListTagsForResource on resource: arn:aws:ecs:eu-west-1:299404798587:task-definition/ecs-cloud-jenkins-agent:128 because no identity-based policy allows the ecs:ListTagsForResource action (Service: AmazonECS; Status Code: 400; Error Code: AccessDeniedException; Request ID: 7627432c-e1ac-43d3-9fdf-340b8d30731f; Proxy: null)
```