### PR TITLE
Update documentation to reflect ability to set multiple labels on ECSTaskTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ Alternative Jenkins URL: The URL used as the Jenkins URL within the ECS containe
 One or several ECS agent templates can be defined for the Amazon EC2 Container Service Cloud. The main reason to create more than one ECS agent template is to use several Docker image to perform build (e.g. java-build-tools, php-build-tools...)
 
 -   `Template name` is used (prefixed with the cloud's name) for the task definition in ECS.
--   `Label`: agent labels used in conjunction with the job level configuration "Restrict where the project can be run / Label expression". ECS agent label could identify the Docker image used for the agent (e.g. `docker` for the jenkinsci/inbound-agent).
--   `Docker image`: identifier of the Docker image to use to create the agents
+-   `Label`: agent labels used in conjunction with the job level configuration "Restrict where the project can be run / Label expression". ECS agent label could identify the Docker image used for the agent (e.g. `docker` for the jenkinsci/inbound-agent).  Multiple, space delimited labels can be specified(e.g. `java11 alpine`). Label expressions within a job such as `java11 && alpine` or `java11 || alpine` are not currently supported.
     `Filesystem root`: working directory used by Jenkins (e.g. `/home/jenkins/`).
-    `Memory`: number of MiB of memory reserved for the container. If your container attempts to exceed the memory allocated here, the container is killed.
+    `Memory`: number of MiB of memory reserved for the container. If your container attempts to exceed the memory allocated here, the container is killed.  
 -   The number of `cpu units` to reserve for the container. A container instance has 1,024 cpu units for every CPU core.
     Advanced Configuration
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -25,7 +25,7 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="Label" field="label" description="The label used to identify this agent in Jenkins.">
+  <f:entry title="Label" field="label" description="Labels used to identify this agent in Jenkins, which must be separated by a space. For example, `java11 alpine` would assign two labels to the agent: `java11` and `alpine`.">
     <f:textbox />
   </f:entry>
   <f:entry title="${%Template Name}" field="templateName" description="The name that will be appended to the ECS cluster name when creating task definitions. Cannot be used with a Task Definition Override.">


### PR DESCRIPTION
Updated the readme and the ECSTaskTemplate label description on the config.jelly to reflect the ability to set multiple space delimited labels.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
