### PR TITLE
amazon-ecs plugin: terminate unsurvivable node to fast fail execution

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputerListener.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputerListener.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ *  Copyright (c) Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.model.Computer;
+import hudson.slaves.ComputerListener;
+import hudson.slaves.OfflineCause;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
+public class ECSComputerListener extends ComputerListener {
+
+    private static final Logger LOGGER = Logger.getLogger(ECSComputerListener.class.getName());
+
+    public static ECSComputerListener getInstance() {
+        return ExtensionList.lookupSingleton(ECSComputerListener.class);
+    }
+
+    @Override
+    public void onOffline(@NonNull Computer c, OfflineCause cause) {
+        if (c instanceof ECSComputer) {
+            LOGGER.log(Level.INFO, "{0} is offline. Cause: {1}", new Object[]{c.getName(), cause});
+            ECSSlave node = ((ECSComputer) c).getNode();
+            /* TODO: Use jenkins.util.Listeners.notify to broadcast events if there are multiple subscribers */
+            terminateNodeIfUnsurvivable(node);
+        }
+    }
+
+    private void terminateNodeIfUnsurvivable(ECSSlave node) {
+        if (node != null && !node.isSurvivable()) {
+            try {
+                LOGGER.log(Level.INFO, "Terminating unsurvivable node {0}", new Object[]{node.getTaskArn()});
+                node.terminate();
+            } catch (InterruptedException | IOException e) {
+                LOGGER.log(Level.WARNING, "Unable to terminate node {0}", new Object[]{e});
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSLauncher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSLauncher.java
@@ -2,6 +2,7 @@
  * The MIT License
  *
  *  Copyright (c) 2015, CloudBees, Inc.
+ *  Copyright (c) Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -125,6 +126,7 @@ public class ECSLauncher extends JNLPLauncher {
             throw Throwables.propagate(ex);
         }
 
+        ECSComputerListener.getInstance();
         launched = true;
 
         try {

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputerListenerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputerListenerTest.java
@@ -1,0 +1,42 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import hudson.slaves.OfflineCause;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.*;
+
+public class ECSComputerListenerTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void unsurvivable_node_is_terminated_when_computer_is_offline() throws Exception {
+        ECSComputer computer = mock(ECSComputer.class);
+        OfflineCause cause = mock(OfflineCause.class);
+        ECSSlave node = mock(ECSSlave.class);
+        Mockito.when(node.isSurvivable()).thenReturn(false);
+        Mockito.when(computer.getNode()).thenReturn(node);
+
+        ECSComputerListener listener = ECSComputerListener.getInstance();
+        listener.onOffline(computer, cause);
+
+        verify(node, times(1)).terminate();
+    }
+
+    @Test
+    public void survivable_node_is_not_terminated_when_computer_is_offline() throws Exception {
+        ECSComputer computer = mock(ECSComputer.class);
+        OfflineCause cause = mock(OfflineCause.class);
+        ECSSlave node = mock(ECSSlave.class);
+        Mockito.when(node.isSurvivable()).thenReturn(true);
+        Mockito.when(computer.getNode()).thenReturn(node);
+
+        ECSComputerListener listener = ECSComputerListener.getInstance();
+        listener.onOffline(computer, cause);
+
+        verify(node, never()).terminate();
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -9,6 +9,8 @@ import java.io.PrintStream;
 
 import com.amazonaws.services.ecs.model.ClientException;
 
+import com.amazonaws.services.ecs.model.Task;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -17,11 +19,54 @@ import org.mockito.Mockito;
 import hudson.model.TaskListener;
 import hudson.slaves.JNLPLauncher;
 
-
 public class ECSSlaveTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
+    private ECSTaskTemplate getTaskTemplate() {
+        return new ECSTaskTemplate(
+                "templateName",
+                "label",
+                "agentContainerName",
+                "taskDefinitionOverride",
+                null,
+                "image",
+                "repositoryCredentials",
+                "launchType",
+                "operatingSystemFamily",
+                "cpuArchitecture",
+                false,
+                null,
+                "networkMode",
+                "remoteFSRoot",
+                false,
+                null,
+                0,
+                0,
+                0,
+                null,
+                null,
+                null,
+                false,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0,
+                false);
+    }
 
     @Test
     public void terminateRunningTask() throws Exception {
@@ -72,47 +117,66 @@ public class ECSSlaveTest {
         verify(ecsService, times(1)).stopTask("mytaskarn", "myclusterarn");
     }
 
-    private ECSTaskTemplate getTaskTemplate() {
-        return new ECSTaskTemplate(
-            "templateName",
-            "label",
-            "agentContainerName",
-            "taskDefinitionOverride",
-            null,
-            "image",
-            "repositoryCredentials",
-            "launchType",
-            "operatingSystemFamily",
-            "cpuArchitecture",
-            false,
-            null,
-            "networkMode",
-            "remoteFSRoot",
-            false,
-            null,
-            0,
-            0,
-            0,
-            null,
-            null,
-            null,
-            false,
-            false,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            0,
-            false);
+    private void test_node_is_survivable_with_last_status_and_desired_status(String lastStatus, String desiredStatus, boolean expectedSurvivable) throws Exception {
+        ECSService ecsService = mock(ECSService.class);
+        ECSCloud cloud = mock(ECSCloud.class);
+        Mockito.when(cloud.getEcsService()).thenReturn(ecsService);
+        ECSTaskTemplate template = getTaskTemplate();
+
+        ECSSlave sut = new ECSSlave(cloud, "myagent", template, new JNLPLauncher());
+        sut.setClusterArn("myclusterarn");
+        sut.setTaskArn("mytaskarn");
+
+        Task task = mock(Task.class);
+        Mockito.when(task.getLastStatus()).thenReturn(lastStatus);
+        Mockito.when(task.getDesiredStatus()).thenReturn(desiredStatus);
+        Mockito.when(ecsService.describeTask(sut.getTaskArn(), sut.getClusterArn())).thenReturn(task);
+
+        if (expectedSurvivable) {
+            Assert.assertTrue(sut.isSurvivable());
+        } else {
+            Assert.assertFalse(sut.isSurvivable());
+        }
+    }
+
+    @Test
+    public void node_is_survivable_if_task_is_provisioning_and_desired_status_is_running() throws Exception {
+        test_node_is_survivable_with_last_status_and_desired_status("PROVISIONING", "RUNNING", true);
+    }
+
+    @Test
+    public void node_is_survivable_if_task_is_running_and_desired_status_is_running() throws Exception {
+        test_node_is_survivable_with_last_status_and_desired_status("RUNNING", "RUNNING", true);
+    }
+
+    @Test
+    public void node_is_not_survivable_if_task_is_stopped_and_desired_status_is_running() throws Exception {
+        test_node_is_survivable_with_last_status_and_desired_status("STOPPED", "RUNNING", false);
+    }
+
+    @Test
+    public void node_is_not_survivable_if_task_is_running_and_desired_status_is_stopped() throws Exception {
+        test_node_is_survivable_with_last_status_and_desired_status("RUNNING", "STOPPED", false);
+    }
+
+    @Test
+    public void node_is_not_survivable_if_task_is_stopped_and_desired_status_is_stopped() throws Exception {
+        test_node_is_survivable_with_last_status_and_desired_status("STOPPED", "STOPPED", false);
+    }
+
+    @Test
+    public void node_is_not_survivable_if_task_cannot_be_found() throws Exception {
+        ECSService ecsService = mock(ECSService.class);
+        ECSCloud cloud = mock(ECSCloud.class);
+        Mockito.when(cloud.getEcsService()).thenReturn(ecsService);
+        ECSTaskTemplate template = getTaskTemplate();
+
+        ECSSlave sut = new ECSSlave(cloud, "myagent", template, new JNLPLauncher());
+        sut.setClusterArn("myclusterarn");
+        sut.setTaskArn("mytaskarn");
+
+        Mockito.when(ecsService.describeTask(sut.getTaskArn(), sut.getClusterArn())).thenReturn(null);
+
+        Assert.assertFalse(sut.isSurvivable());
     }
 }


### PR DESCRIPTION
This patch introduces ECSComputerListener and provides an onOffline event hook, which terminates the node if it is in an "unsurvivable" state. This enables the user execution to fast fail if the ECS task is killed, e.g. due to OOM error.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [TBD] Ensure that the pull request title represents the desired changelog entry - Need advice which version this change should go to
- [X] Please describe what you did -  See commit message
- [X] Link to relevant issues in GitHub or Jira -  https://github.com/jenkinsci/amazon-ecs-plugin/issues/312
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
