### PR TITLE
[#317] Pass noproxy list to the client

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/aws/BaseAWSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/aws/BaseAWSService.java
@@ -6,6 +6,7 @@ import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
+import com.google.common.base.Joiner;
 import hudson.ProxyConfiguration;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
@@ -37,6 +38,10 @@ public abstract class BaseAWSService {
             clientConfiguration.setProxyPort(proxy.port);
             clientConfiguration.setProxyUsername(proxy.getUserName());
             clientConfiguration.setProxyPassword(proxy.getPassword());
+            if (proxy.getNoProxyHost() != null) {
+                String[] noProxyParts = proxy.getNoProxyHost().split("[ \t\n,|]+");
+                clientConfiguration.setNonProxyHosts(Joiner.on(',').join(noProxyParts));
+            }
         }
 
         // Default is 3. 10 helps us actually utilize the SDK's backoff strategy


### PR DESCRIPTION
Respect the Jenkins No Proxy Host configuration. In our environment we have a proxy configuration to allow our instance to hit some external sites, but since we are running our instance in AWS we would like to use the VPC endpoint for interacting with ECS rather than the traffic going over the internet. Without this change the traffic was attempting to go through our proxy despite us having *.amazonaws.com in the no proxy list and was getting blocked.

Fixes #317

### Testing done

Built the plugin and applied it to our instance and verified that it was working with *.amazonaws.com in our no proxy list.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
