### PR TITLE
use custom retry condition to log retries

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/aws/BaseAWSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/aws/BaseAWSService.java
@@ -4,6 +4,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
+import com.amazonaws.retry.RetryPolicy;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import hudson.ProxyConfiguration;
@@ -39,10 +40,19 @@ public abstract class BaseAWSService {
             clientConfiguration.setProxyPassword(proxy.getPassword());
         }
 
+        clientConfiguration.setRetryPolicy(ecsRetryPolicy());
+
         // Default is 3. 10 helps us actually utilize the SDK's backoff strategy
         // The strategy will wait up to 20 seconds per request (after multiple failures)
         clientConfiguration.setMaxErrorRetry(10);
 
         return clientConfiguration;
+    }
+
+    private RetryPolicy ecsRetryPolicy() {
+        return new RetryPolicy(new RetryCondition(),
+                       null,
+                       10,
+                       true);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/aws/RetryCondition.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/aws/RetryCondition.java
@@ -1,0 +1,21 @@
+package com.cloudbees.jenkins.plugins.amazonecs.aws;
+
+import java.util.logging.Logger;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonWebServiceRequest;
+
+import java.util.logging.Level;
+
+public class RetryCondition extends com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition {
+    private static final Logger LOGGER = Logger.getLogger(RetryCondition.class.getName());
+
+    @Override
+    public boolean shouldRetry(AmazonWebServiceRequest originalRequest, AmazonClientException exception, int retriesAttempted){
+        if (super.shouldRetry(originalRequest, exception, retriesAttempted)){
+            LOGGER.log(Level.INFO, "retrying request {0} because of {1}, retried {2} time(s)", new Object[]{originalRequest, exception, retriesAttempted});
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This work comes as a followup on my original PR to implement retries with exponential backoff https://github.com/jenkinsci/amazon-ecs-plugin/pull/193

This PR is a minor quality of life improvement for the ECS Plugin. All this PR does is add logging when there are retries to the AWS API. I have been using this at my employer with success, as it has helped us rule out various infrastructure hiccups and slowdowns on our Jenkins setup.

Other users of this plugin that run on the scale of many thousands of jobs a day may find this useful, as the retry logs can act as an indicator for why jobs are stuck in the queue for a few extra minutes (especially when experiencing rate-limiting by AWS).


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
