### PR TITLE
[#326] Set number of executors on ECS Agent

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -98,7 +98,7 @@ public class ECSSlave extends AbstractCloudSlave {
             name,
             "ECS Agent",
             template.makeRemoteFSRoot(name),
-            1,
+            Math.max(1, cloud.getNumExecutors()),
             Mode.EXCLUSIVE,
             template.getLabel(),
             launcher,

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -1,9 +1,5 @@
 package com.cloudbees.jenkins.plugins.amazonecs;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
@@ -18,6 +14,8 @@ import org.mockito.Mockito;
 
 import hudson.model.TaskListener;
 import hudson.slaves.JNLPLauncher;
+
+import static org.mockito.Mockito.*;
 
 public class ECSSlaveTest {
 
@@ -178,5 +176,31 @@ public class ECSSlaveTest {
         Mockito.when(ecsService.describeTask(sut.getTaskArn(), sut.getClusterArn())).thenReturn(null);
 
         Assert.assertFalse(sut.isSurvivable());
+    }
+
+    @Test
+    public void agent_has_1_executor_as_default() throws Exception {
+        ECSService ecsService = mock(ECSService.class);
+        ECSCloud cloud = mock(ECSCloud.class);
+        Mockito.when(cloud.getEcsService()).thenReturn(ecsService);
+        ECSTaskTemplate template = getTaskTemplate();
+
+        ECSSlave sut = new ECSSlave(cloud, "myagent", template, new JNLPLauncher());
+
+        Assert.assertEquals(1, sut.getNumExecutors());
+    }
+
+    @Test
+    public void agent_has_4_executors_when_configured() throws Exception {
+        ECSService ecsService = mock(ECSService.class);
+        ECSCloud cloud = mock(ECSCloud.class);
+        Mockito.when(cloud.getEcsService()).thenReturn(ecsService);
+        ECSTaskTemplate template = getTaskTemplate();
+
+        when(cloud.getNumExecutors()).thenReturn(4);
+
+        ECSSlave sut = new ECSSlave(cloud, "myagent", template, new JNLPLauncher());
+
+        Assert.assertEquals(4, sut.getNumExecutors());
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The number of executors on ECS Agent is currently hardcoded to 1 even though the number of executors is configurable is the ECS Cloud settings. This fix sets the number of executors from the ECS Cloud settings.

Fixes #326 

### Testing done
* Added tests for both default (1) executor and multiple executors.
* Plugin build and tested on our own Jenkins instances. Multiple jobs can be executed in parallel on single ECS Agent.
* Confirmed settings in Script Console:
```groovy
// Print NumExecutors in ECS Cloud settings
println "NumExecutors: " + com.cloudbees.jenkins.plugins.amazonecs.ECSCloud.getByName("ecs").getNumExecutors()
// Result: NumExecutors: 4

// Print NumExecutors in ECS Agent
jenkins.model.Jenkins.instance.nodes.each { node ->
  println "NumExecutors: " + node.getNumExecutors()
}
// NumExecutors: 4
// Result: [com.cloudbees.jenkins.plugins.amazonecs.ECSSlave[ecs-test-pjt74]]
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
