### PR TITLE
Removed 2 unnecessary stubbings in ECSSlaveTest.java

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -77,7 +77,6 @@ public class ECSSlaveTest {
 
         ByteArrayOutputStream bo = new ByteArrayOutputStream();
         TaskListener listener = mock(TaskListener.class);
-        Mockito.when(listener.getLogger()).thenReturn(new PrintStream(bo));
         ECSTaskTemplate template = getTaskTemplate();
 
         ECSSlave sut = new ECSSlave(cloud, "myagent", template, new JNLPLauncher());
@@ -103,7 +102,6 @@ public class ECSSlaveTest {
 
         ByteArrayOutputStream bo = new ByteArrayOutputStream();
         TaskListener listener = mock(TaskListener.class);
-        Mockito.when(listener.getLogger()).thenReturn(new PrintStream(bo));
         ECSTaskTemplate template = getTaskTemplate();
 
         ECSSlave sut = new ECSSlave(cloud, "myagent", template, new JNLPLauncher());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
In our analysis of the project, we observed that the test `ECSSlaveTest.terminate_ThrowsException_ignoreException` and `ECSSlaveTest.terminateRunningTask` contain unnecessary stubbings. 

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.
<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
