### PR TITLE
Add possibility to override ephemeralStorageSizeInGiB from declarative pipeline

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
@@ -41,6 +41,7 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
     private int memory;
     private int memoryReservation;
     private int cpu;
+    private Integer ephemeralStorageSizeInGiB;
     private int sharedMemorySize;
     private String subnets;
     private String securityGroups;
@@ -186,6 +187,14 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
     public void setCpu(int cpu) {
         this.cpu = cpu;
         overrides.add("cpu");
+    }
+
+    public Integer getEphemeralStorageSizeInGiB() { return ephemeralStorageSizeInGiB; }
+
+    @DataBoundSetter
+    public void setEphemeralStorageSizeInGiB(Integer ephemeralStorageSizeInGiB) {
+        this.ephemeralStorageSizeInGiB = ephemeralStorageSizeInGiB;
+        overrides.add("ephemeralStorageSizeInGiB");
     }
 
     public int getSharedMemorySize() {
@@ -434,6 +443,10 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
 
         if (cpu != 0) {
             argMap.put("cpu", cpu);
+        }
+
+        if (ephemeralStorageSizeInGiB != null && ephemeralStorageSizeInGiB != 0 ) {
+            argMap.put("ephemeralStorageSizeInGiB", ephemeralStorageSizeInGiB);
         }
 
         if (sharedMemorySize != 0) {


### PR DESCRIPTION
This PR allows to use ephemeralStorageSizeInGiB in declarative pipeline as per example

```
 agent {
        ecs {
            inheritFrom 'example-agent'
            cpu 1024
            memory 2048
            ephemeralStorageSizeInGiB 50
            image 'jenkins/inbound-agent:latest'
            }
        }
```


### Testing done
<img width="975" alt="Screenshot 2023-11-17 at 13 05 11" src="https://github.com/jenkinsci/amazon-ecs-plugin/assets/13534363/0b8b4f7a-74f3-4453-86b4-cbfd5dbffe1c">
<img width="426" alt="Screenshot 2023-11-17 at 13 12 04" src="https://github.com/jenkinsci/amazon-ecs-plugin/assets/13534363/3af09043-01e0-435a-b121-4fecfc6d3e00">


This PR solves issue https://github.com/jenkinsci/amazon-ecs-plugin/issues/337

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
