### PR TITLE
[#370] Use the correct separator character for noproxy

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/aws/BaseAWSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/aws/BaseAWSService.java
@@ -41,7 +41,7 @@ public abstract class BaseAWSService {
             clientConfiguration.setProxyPassword(proxy.getPassword());
             if (proxy.getNoProxyHost() != null) {
                 String[] noProxyParts = proxy.getNoProxyHost().split("[ \t\n,|]+");
-                clientConfiguration.setNonProxyHosts(Joiner.on(',').join(noProxyParts));
+                clientConfiguration.setNonProxyHosts(Joiner.on('|').join(noProxyParts));
             }
         }
 


### PR DESCRIPTION
The AWS SDK expects to use pipe instead of comma for the noproxy list. Introduced by #318 

Fixes #370 

### Testing done

<!-- Comment:
Tested in our environment with the noproxy list configured to include the ECS endpoint
-->

### Submitter checklist
- [ x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ x ] Link to relevant issues in GitHub or Jira
- [ x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
