### PR TITLE
[#375] Allow cross-account AWS IAM role assumption into opt-in regions

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -82,6 +82,7 @@ public class ECSCloud extends Cloud {
     private final String cluster;
     private String regionName;
     private String assumedRoleArn;
+    private String authRegion;
     @CheckForNull
     private String tunnel;
     private String jenkinsUrl;
@@ -121,7 +122,7 @@ public class ECSCloud extends Cloud {
 
     synchronized ECSService getEcsService() {
         if (ecsService == null) {
-            ecsService = new ECSService(credentialsId, assumedRoleArn, regionName);
+            ecsService = new ECSService(credentialsId, assumedRoleArn, authRegion, regionName);
         }
         return ecsService;
     }
@@ -164,6 +165,11 @@ public class ECSCloud extends Cloud {
         return assumedRoleArn;
     }
 
+
+    public String getAuthRegion() {
+        return authRegion;
+    }
+
     @DataBoundSetter
     public void setRegionName(String regionName) {
         this.regionName = regionName;
@@ -172,6 +178,11 @@ public class ECSCloud extends Cloud {
     @DataBoundSetter
     public void setAssumedRoleArn(String assumedRoleArn) {
         this.assumedRoleArn = assumedRoleArn;
+    }
+    
+    @DataBoundSetter
+    public void setAuthRegion(String authRegion) {
+        this.authRegion = authRegion;
     }
 
     public String getTunnel() {
@@ -428,12 +439,20 @@ public class ECSCloud extends Cloud {
         }
     }
 
-    public static Region getRegion(String regionName) {
-        if (StringUtils.isNotEmpty(regionName)) {
-            return RegionUtils.getRegion(regionName);
-        } else {
-            return Region.getRegion(Regions.US_EAST_1);
+    public ListBoxModel doFillAuthRegionItems() {
+        final ListBoxModel options = new ListBoxModel();
+        for (Region region : RegionUtils.getRegions()) {
+            options.add(region.getName());
         }
+        return options;
+    }
+
+    public ListBoxModel doFillRegionNameItems() {
+        final ListBoxModel options = new ListBoxModel();
+        for (Region region : RegionUtils.getRegions()) {
+            options.add(region.getName());
+        }
+        return options;
     }
 
     public String getJenkinsUrl() {
@@ -507,9 +526,17 @@ public class ECSCloud extends Cloud {
             }
             return options;
         }
+        
+        public ListBoxModel doFillAuthRegionItems() {
+            final ListBoxModel options = new ListBoxModel();
+            for (Region region : RegionUtils.getRegions()) {
+                options.add(region.getName());
+            }
+            return options;
+        }
 
-        public ListBoxModel doFillClusterItems(@QueryParameter String credentialsId, @QueryParameter String assumedRoleArn, @QueryParameter String regionName) {
-            ECSService ecsService = new ECSService(credentialsId, assumedRoleArn, regionName);
+        public ListBoxModel doFillClusterItems(@QueryParameter String credentialsId, @QueryParameter String assumedRoleArn, @QueryParameter String authRegion, @QueryParameter String regionName) {
+            ECSService ecsService = new ECSService(credentialsId, assumedRoleArn, authRegion, regionName);
             try {
                 final AmazonECS client = ecsService.getAmazonECSClient();
                 final List<String> allClusterArns = new ArrayList<String>();

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -76,7 +76,7 @@ public class ECSService extends BaseAWSService {
     @Nonnull
     private final Supplier<AmazonECS> clientSupplier;
 
-    public ECSService(String credentialsId, String assumedRoleArn, String regionName) {
+    public ECSService(String credentialsId, String assumedRoleArn, String authRegion, String regionName) {
         this.clientSupplier = () -> {
             AmazonECSClientBuilder builder = AmazonECSClientBuilder
                     .standard()
@@ -94,7 +94,13 @@ public class ECSService extends BaseAWSService {
                         .withCredentials(credentials);
             }
             else if (StringUtils.isNotBlank(assumedRoleArn)) {
-                builder.withCredentials(getCredentialsForRole(assumedRoleArn, regionName));
+		if (StringUtils.isNotBlank(authRegion)) {
+                    builder.withCredentials(getCredentialsForRole(assumedRoleArn, authRegion));
+		}
+		else {
+                    builder.withCredentials(getCredentialsForRole(assumedRoleArn, regionName));
+		}
+
             }
 
             LOGGER.log(Level.FINE, "Selected Region: {0}", regionName);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -1429,10 +1429,11 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
             public ListBoxModel doFillProviderItems(
                 @RelativePath("../..") @QueryParameter String credentialsId,
                 @RelativePath("../..") @QueryParameter String assumedRoleArn,
+                @RelativePath("../..") @QueryParameter String authRegion,
                 @RelativePath("../..") @QueryParameter String regionName,
                 @RelativePath("../..") @QueryParameter String cluster
             ){
-                ECSService ecsService = new ECSService(credentialsId, assumedRoleArn, regionName);
+                ECSService ecsService = new ECSService(credentialsId, assumedRoleArn, authRegion, regionName);
                 final AmazonECS client = ecsService.getAmazonECSClient();
                 final List<Cluster> allClusters = new ArrayList<Cluster>();
                 DescribeClustersResult result = client.describeClusters(new DescribeClustersRequest().withClusters(cluster));

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -39,6 +39,10 @@
       <f:textbox />
     </f:entry>
 
+    <f:entry field="authRegion" title="${%Amazon IAM Auth Region}" description="AWS regionName for credentials authentication. If not specified, use us-east-1.">
+      <f:select />
+    </f:entry>
+
     <f:entry field="regionName" title="${%Amazon ECS Region Name}" description="AWS regionName for ECS. If not specified, use us-east-1.">
       <f:select />
     </f:entry>

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -170,6 +170,7 @@ public class ECSCloudTest {
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setMaxAgents(14);
         sut.setTemplates(templates);
+        sut.setAuthRegion("eu-west-1");
         sut.setRegionName("eu-west-1");
         sut.setNumExecutors(1);
         sut.setJenkinsUrl("http://jenkins.local");
@@ -192,6 +193,7 @@ public class ECSCloudTest {
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setMaxAgents(0);
         sut.setTemplates(templates);
+        sut.setAuthRegion("eu-west-1");
         sut.setRegionName("eu-west-1");
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
@@ -213,6 +215,7 @@ public class ECSCloudTest {
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setMaxAgents(10);
         sut.setTemplates(templates);
+        sut.setAuthRegion("eu-west-1");
         sut.setRegionName("eu-west-1");
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
@@ -234,6 +237,7 @@ public class ECSCloudTest {
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setMaxAgents(10);
         sut.setTemplates(templates);
+        sut.setAuthRegion("eu-west-1");
         sut.setRegionName("eu-west-1");
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);
@@ -255,6 +259,7 @@ public class ECSCloudTest {
         ECSCloud sut = new ECSCloud("mycloud", "", "", "mycluster");
         sut.setMaxAgents(1);
         sut.setTemplates(templates);
+        sut.setAuthRegion("eu-west-1");
         sut.setRegionName("eu-west-1");
         sut.setJenkinsUrl("http://jenkins.local");
         sut.setSlaveTimeoutInSeconds(5);


### PR DESCRIPTION

Added authRegion drop-down list-box & variable to allow explicitly stating the region for authenticating with AWS IAM. This will address Issue #375 by permitting authentication with a region that is opted-in in the source AWS account, while accessing ECS clusters in an opt-in region in the target account (which is not opted-in for the source account).

The solution was adding an `authRegion` list-box to choose the region used for IAM authentication, which is stored in an `authRegion` variable. This box works in exactly the same manner as the `regionName` variable box, but by separating them it is now possible to authenticate with AWS IAM in region A while using ECS clusters in region B.

<!-- Please describe your pull request here. -->

### Testing done by:
1. Adding authRegion to the fields in the automated test
2. Installing the plugin and running it on a local installation of LTS Jenkins Controller (see attached screenshot)
<img width="1034" alt="ecs_cloud_screenshot" src="https://github.com/user-attachments/assets/19e5b230-686f-4341-a6f1-fc1d4e1fca27" />
3. Successfully viewing and running ECS agents on ECS clusters in an opted-in region in the target account (which is not opted-in for the Jenkins Controller account), using IAM assume-role for access to the clusters.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes - *none found*
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
