### PR TITLE
Add support for ECS agent pools to avoid cold start

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+-   Feature - Support ECS agent pools to avoid cold start
+
 ## 1.35 / 1.36
 
 -   allow certain classes to be used from other plugins (#192)

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool.java
@@ -1,0 +1,199 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import antlr.ANTLRException;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Label;
+import hudson.scheduler.CronTabList;
+import hudson.util.FormValidation;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.annotation.CheckForNull;
+import java.io.Serializable;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.UUID;
+
+public class ECSAgentPool extends AbstractDescribableImpl<ECSAgentPool> implements Serializable {
+
+    private static final long serialVersionUID = 7831619059473567435L;
+
+    /**
+     * Unique identifier for this pool.
+     */
+    private String id;
+
+
+    public ECSAgentPool(@CheckForNull String label, String id, int minIdleAgents, @CheckForNull String maintainSchedule, int maxIdleMinutes, @CheckForNull String description) {
+        this.label = label;
+        this.id = StringUtils.isBlank(id) ? UUID.randomUUID().toString() : id;
+        this.minIdleAgents = minIdleAgents;
+        this.maintainSchedule = maintainSchedule;
+        this.maxIdleMinutes = maxIdleMinutes;
+        this.description = description;
+    }
+
+    /**
+     * White-space separated list of {@link hudson.model.Node} labels.
+     *
+     * @see Label
+     */
+    @CheckForNull
+    private final String label;
+
+    /**
+     * Minimum number of idle agents to keep running for this template.
+     */
+    private int minIdleAgents;
+
+    /**
+     * Cron schedule defining when {@link #minIdleAgents} should be maintained.
+     */
+    @CheckForNull
+    private String maintainSchedule;
+
+    private int maxIdleMinutes;
+
+    @CheckForNull
+    private String description;
+
+    @DataBoundSetter
+    public void setMinIdleAgents(int minIdleAgents) {
+        this.minIdleAgents = Math.max(0, minIdleAgents);
+    }
+
+    @DataBoundSetter
+    public void setMaintainSchedule(String maintainSchedule) {
+        this.maintainSchedule = StringUtils.trimToNull(maintainSchedule);
+    }
+
+    @DataBoundSetter
+    public void setMaxIdleMinutes(int maxIdleMinutes) {
+        this.maxIdleMinutes = maxIdleMinutes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @DataBoundSetter
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @CheckForNull
+    public String getLabel() {
+        return label;
+    }
+
+    public int getMinIdleAgents() {
+        return minIdleAgents;
+    }
+
+    public String getMaintainSchedule() {
+        return maintainSchedule;
+    }
+
+    public boolean isScheduleActive() {
+        if (StringUtils.isEmpty(maintainSchedule)) {
+            return true;
+        }
+        try {
+            CronTabList tabs = CronTabList.create(maintainSchedule);
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(new Date());
+            return tabs.check(calendar);
+        } catch (ANTLRException e) {
+            return true;
+        }
+    }
+
+    public int getMaxIdleMinutes() {
+        return maxIdleMinutes;
+    }
+
+    @CheckForNull
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(@CheckForNull String description) {
+        this.description = description;
+    }
+
+    private Object readResolve() {
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+        }
+        return this;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ECSAgentPool> {
+        @Override
+        public String getDisplayName() {
+            return Messages.agentPool();
+        }
+
+        public FormValidation doCheckLabel(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.error("Label is required");
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckMinIdleAgents(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.ok();
+            }
+            try {
+                int v = Integer.parseInt(value);
+                if (v >= 0) {
+                    return FormValidation.ok();
+                }
+            } catch (NumberFormatException e) {
+                // fall through to error
+            }
+            return FormValidation.error("Must be a non-negative integer");
+        }
+
+        public FormValidation doCheckMaxIdleMinutes(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.ok();
+            }
+            try {
+                int v = Integer.parseInt(value);
+                if (v >= 0) {
+                    return FormValidation.ok();
+                }
+            } catch (NumberFormatException e) {
+                // fall through to error
+            }
+            return FormValidation.error("Must be a non-negative integer");
+        }
+
+        public FormValidation doCheckMaintainSchedule(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.ok();
+            }
+            try {
+                CronTabList.create(value);
+                return FormValidation.ok();
+            } catch (ANTLRException e) {
+                return FormValidation.error(e, e.getMessage());
+            }
+        }
+
+        public FormValidation doCheckDescription(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.error("Description is required");
+            }
+            return FormValidation.ok();
+        }
+    }
+}
+

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool.java
@@ -27,7 +27,7 @@ public class ECSAgentPool extends AbstractDescribableImpl<ECSAgentPool> implemen
      */
     private String id;
 
-
+    @DataBoundConstructor
     public ECSAgentPool(@CheckForNull String label, String id, int minIdleAgents, @CheckForNull String maintainSchedule, int maxIdleMinutes, @CheckForNull String description) {
         this.label = label;
         this.id = StringUtils.isBlank(id) ? UUID.randomUUID().toString() : id;

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPoolMaintainer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPoolMaintainer.java
@@ -1,0 +1,106 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import hudson.Extension;
+import hudson.model.AsyncPeriodicWork;
+import hudson.model.Computer;
+import hudson.model.TaskListener;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.RandomStringUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+
+@Extension
+public class ECSAgentPoolMaintainer extends AsyncPeriodicWork {
+
+    private static final Logger LOGGER = Logger.getLogger(ECSAgentPoolMaintainer.class.getName());
+
+    public ECSAgentPoolMaintainer() {
+        super("ECS Agent Pool Maintainer");
+    }
+
+    @Override
+    public long getRecurrencePeriod() {
+        return TimeUnit.MINUTES.toMillis(1);
+    }
+
+    @Override
+    protected void execute(TaskListener listener) throws IOException, InterruptedException {
+        for (Cloud c : Jenkins.get().clouds) {
+            if (c instanceof ECSCloud) {
+                ECSCloud cloud = (ECSCloud) c;
+                for (ECSAgentPool pool : cloud.getAgentPools()) {
+
+                    LOGGER.log(Level.INFO, "Pool: {0}, Required: {1}, Labels: [{2}]",  new Object[]{pool.getId(), pool.getMinIdleAgents(), pool.getLabel()});
+
+                    if (pool.getMinIdleAgents() <= 0 || !pool.isScheduleActive()) {
+                        continue;
+                    }
+
+                    final ECSTaskTemplate template = cloud.getTemplate(pool.getLabel());
+
+                    if (template != null) {
+
+                        int current = countIdle(pool);
+                        LOGGER.log(Level.INFO, "Pool: {0}, Required: {1}, Current: {2}, Labels: [{3}] ",  new Object[]{pool.getId(), pool.getMinIdleAgents(), current, pool.getLabel()});
+
+                        while (current < pool.getMinIdleAgents()) {
+                            try {
+                                String agentName = cloud.getDisplayName() + "-" + pool.getLabel() + "-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+                                ECSPoolSlave ecsPoolSlave = new ECSPoolSlave(cloud, pool, agentName, template, new ECSLauncher(cloud, cloud.getTunnel(), null));
+                                Jenkins.get().addNode(ecsPoolSlave);
+                                Computer computer = ecsPoolSlave.toComputer();
+                                if (computer != null) {
+                                    computer.connect(false);
+                                }
+                                LOGGER.log(Level.INFO, "Launch new agent.. Pool: {0}, Name: {1}",  new Object[]{pool.getId(), agentName});
+
+                                current++;
+                            } catch (Exception ex) {
+                                LOGGER.log(Level.WARNING, "Failed to pre-launch agent for template " + template.getTemplateName(), ex);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private int countIdle(@Nonnull ECSAgentPool ecsAgentPool) {
+        Set<String> poolLabels = new HashSet<>(Arrays.asList(ecsAgentPool.getLabel().split("\\s+")));
+        int count = 0;
+
+        for (Computer computer : Jenkins.get().getComputers()) {
+            if (!(computer instanceof ECSComputer)) {
+                continue;
+            }
+
+            if (computer.getNode() == null) {
+                continue;
+            }
+
+            if (!(computer.getNode() instanceof ECSPoolSlave node)) {
+                continue;
+            }
+
+            if (!ecsAgentPool.getId().equals(node.getId())) {
+                continue;
+            }
+
+            Set<String> nodeLabels = new HashSet<>(Arrays.asList(node.getLabelString().split("\\s+")));
+            if (nodeLabels.containsAll(poolLabels) && computer.isIdle()) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPoolMaintainer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPoolMaintainer.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -75,8 +76,9 @@ public class ECSAgentPoolMaintainer extends AsyncPeriodicWork {
     }
 
     private int countIdle(@Nonnull ECSAgentPool ecsAgentPool) {
-        Set<String> poolLabels = new HashSet<>(Arrays.asList(ecsAgentPool.getLabel().split("\\s+")));
         int count = 0;
+
+        Set<String> poolLabels = new HashSet<>(Arrays.asList(Objects.requireNonNull(ecsAgentPool.getLabel()).split("\\s+")));
 
         for (Computer computer : Jenkins.get().getComputers()) {
             if (!(computer instanceof ECSComputer)) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -77,6 +77,7 @@ public class ECSCloud extends Cloud {
 
     private static final Logger LOGGER = Logger.getLogger(ECSCloud.class.getName());
 
+    private List<ECSAgentPool> agentPools;
     private List<ECSTaskTemplate> templates;
     private final String credentialsId;
     private final String cluster;
@@ -127,12 +128,17 @@ public class ECSCloud extends Cloud {
     }
 
     @Nonnull
+    public List<ECSAgentPool> getAgentPools() {
+        return agentPools != null ? agentPools : Collections.<ECSAgentPool> emptyList();
+    }
+
+    @Nonnull
     public List<ECSTaskTemplate> getTemplates() {
         return templates != null ? templates : Collections.<ECSTaskTemplate> emptyList();
     }
 
     @Nonnull
-    private List<ECSTaskTemplate> getAllTemplates() {
+    public List<ECSTaskTemplate> getAllTemplates() {
         List<ECSTaskTemplate> dynamicTemplates = TaskTemplateMap.get().getTemplates(this);
         List<ECSTaskTemplate> allTemplates = new CopyOnWriteArrayList<>();
 
@@ -141,6 +147,11 @@ public class ECSCloud extends Cloud {
             allTemplates.addAll(templates);
         }
         return allTemplates;
+    }
+
+    @DataBoundSetter
+    public void setAgentPools(List<ECSAgentPool> agentPools) {
+        this.agentPools = agentPools;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSPoolSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSPoolSlave.java
@@ -1,0 +1,28 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import hudson.model.Descriptor;
+import hudson.slaves.CloudRetentionStrategy;
+import hudson.slaves.ComputerLauncher;
+import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+public class ECSPoolSlave extends ECSSlave {
+
+    private final String id;
+
+    public ECSPoolSlave(@Nonnull ECSCloud cloud, @Nonnull ECSAgentPool ecsAgentPool, @Nonnull String name, ECSTaskTemplate template,
+                        @Nonnull ComputerLauncher launcher) throws Descriptor.FormException, IOException {
+        super(cloud, name, template, launcher, cloud.getRetainAgents() ?
+                new CloudRetentionStrategy(cloud.getRetentionTimeout()) :
+                new OnceRetentionStrategy(ecsAgentPool.getMaxIdleMinutes()));
+        this.setNumExecutors(cloud.getNumExecutors());
+        this.id = ecsAgentPool.getId();
+
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -26,35 +26,7 @@
 package com.cloudbees.jenkins.plugins.amazonecs;
 
 import com.amazonaws.services.ecs.AmazonECS;
-import com.amazonaws.services.ecs.model.AwsVpcConfiguration;
-import com.amazonaws.services.ecs.model.ContainerDefinition;
-import com.amazonaws.services.ecs.model.EFSAuthorizationConfig;
-import com.amazonaws.services.ecs.model.EFSAuthorizationConfigIAM;
-import com.amazonaws.services.ecs.model.EFSTransitEncryption;
-import com.amazonaws.services.ecs.model.EFSVolumeConfiguration;
-import com.amazonaws.services.ecs.model.HostEntry;
-import com.amazonaws.services.ecs.model.HostVolumeProperties;
-import com.amazonaws.services.ecs.model.KeyValuePair;
-import com.amazonaws.services.ecs.model.LaunchType;
-import com.amazonaws.services.ecs.model.OSFamily;
-import com.amazonaws.services.ecs.model.CPUArchitecture;
-import com.amazonaws.services.ecs.model.CapacityProviderStrategyItem;
-import com.amazonaws.services.ecs.model.LinuxParameters;
-import com.amazonaws.services.ecs.model.MountPoint;
-import com.amazonaws.services.ecs.model.NetworkMode;
-import com.amazonaws.services.ecs.model.PlacementStrategy;
-import com.amazonaws.services.ecs.model.PlacementStrategyType;
-import com.amazonaws.services.ecs.model.PortMapping;
-import com.amazonaws.services.ecs.model.RegisterTaskDefinitionRequest;
-import com.amazonaws.services.ecs.model.RepositoryCredentials;
-import com.amazonaws.services.ecs.model.Volume;
-import com.amazonaws.services.ecs.model.DescribeClustersRequest;
-import com.amazonaws.services.ecs.model.DescribeClustersResult;
-import com.amazonaws.services.ecs.model.Cluster;
-import com.amazonaws.services.ecs.model.Ulimit;
-import com.amazonaws.services.ecs.model.UlimitName;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
+import com.amazonaws.services.ecs.model.*;
 import com.amazonaws.services.elasticfilesystem.model.AccessPointDescription;
 import com.amazonaws.services.elasticfilesystem.model.FileSystemDescription;
 import com.cloudbees.jenkins.plugins.amazonecs.aws.EFSService;
@@ -66,7 +38,7 @@ import hudson.model.Label;
 import hudson.model.labels.LabelAtom;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import jakarta.servlet.ServletException;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -76,15 +48,16 @@ import org.kohsuke.stapler.QueryParameter;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import jakarta.servlet.ServletException;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -353,6 +326,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
      */
     private boolean enableExecuteCommand;
 
+
     @DataBoundConstructor
     public ECSTaskTemplate(String templateName,
                            @Nullable String label,
@@ -518,6 +492,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     public void setDnsSearchDomains(String dnsSearchDomains) {
         this.dnsSearchDomains = StringUtils.trimToNull(dnsSearchDomains);
     }
+
 
     public boolean isFargate() {
         if (!this.defaultCapacityProvider && this.capacityProviderStrategies != null && ! this.capacityProviderStrategies.isEmpty()) {
@@ -927,7 +902,6 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                                                         enableExecuteCommand);
         merged.setLogDriver(logDriver);
         merged.setEntrypoint(entrypoint);
-
         return merged;
     }
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool/config.jelly
@@ -1,0 +1,28 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <j:choose>
+        <j:when test="${instance != null &amp;&amp; instance.id != null}">
+            <f:entry title="${%Id}" field="id">
+                <j:out value="${instance.id}"/>
+                <input type="hidden" name="id" value="${instance.id}"/>
+            </f:entry>
+        </j:when>
+        <j:otherwise>
+        </j:otherwise>
+    </j:choose>
+    <f:entry title="${%Label}" field="label" description="Labels used to identify this agent in Jenkins, which must be separated by a space. For example, `java11 alpine` would assign two labels to the agent: `java11` and `alpine`.">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Minimum Idle Agents}" field="minIdleAgents">
+        <f:number default="0"/>
+    </f:entry>
+    <f:entry title="${%Maintain Schedule}" field="maintainSchedule">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Max Time in Idle (Minutes)}" field="maxIdleMinutes">
+        <f:number default="0"/>
+    </f:entry>
+    <f:entry title="${%Description}" field="description">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool/help-maintainSchedule.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool/help-maintainSchedule.html
@@ -1,0 +1,5 @@
+<p>
+    Cron syntax controlling when the plugin should maintain the minimum
+    number of idle agents. Leave empty to keep the pool at all times.
+    Uses the standard Jenkins cron format.
+</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool/help-maxIdleMinutes.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool/help-maxIdleMinutes.html
@@ -1,0 +1,3 @@
+<p>
+    Maximum number of minutes to keep an agent idle before it is terminated.
+</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool/help-minIdleAgents.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPool/help-minIdleAgents.html
@@ -1,0 +1,5 @@
+<p>
+    Number of agent tasks to keep pre-launched and ready for use.
+    When the number of idle agents falls below this value, the plugin
+    will start additional agents to replenish the pool.
+</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -95,5 +95,15 @@
         </f:entry>
       </f:repeatableProperty>
     </f:entry>
+
+    <f:entry title="${%ECS Agent Pools}">
+      <f:repeatableProperty field="agentPools" >
+        <f:entry title="">
+          <div align="right">
+            <f:repeatableDeleteButton />
+          </div>
+        </f:entry>
+      </f:repeatableProperty>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/Messages.properties
@@ -24,4 +24,5 @@
 #
 
 displayName=Amazon EC2 Container Service Cloud
-template=ECS Task template
+template=ECS Task templat
+agentPool=ECS Agent Pool


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This update introduces the functionality to maintain a pool of pre-warmed ECS agents. This allows Jenkins to execute tasks more quickly by avoiding the delay caused when containers are started from scratch.
To achieve this, the classes ECSAgentPool and ECSAgentPoolMaintainer were added, along with adjustments to ECSCloud, ECSPoolSlave, and other related components.

Testing done
The new functionality was manually verified by running Jenkins with a configured agent pool. It was observed that the preexisting agents are used correctly and maintained according to the configuration.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed


Tests: 

![image](https://github.com/user-attachments/assets/8d39a8db-d960-46f7-9af2-97c565b45c61)
![image](https://github.com/user-attachments/assets/910cc0f3-b9b3-4037-a741-95707967e321)
![image](https://github.com/user-attachments/assets/6083aabd-b367-410c-8d25-88b6b3861443)

