### PR TITLE
fix: prevent duplicate ECS agent provisioning while JNLP agent is starting, #311, #416

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -133,7 +133,10 @@ public class ECSCloud extends Cloud {
 
     @Nonnull
     private List<ECSTaskTemplate> getAllTemplates() {
-        List<ECSTaskTemplate> dynamicTemplates = TaskTemplateMap.get().getTemplates(this);
+        TaskTemplateMap taskTemplateMap = TaskTemplateMap.get();
+        List<ECSTaskTemplate> dynamicTemplates = taskTemplateMap != null
+                ? taskTemplateMap.getTemplates(this)
+                : Collections.emptyList();
         List<ECSTaskTemplate> allTemplates = new CopyOnWriteArrayList<>();
 
         allTemplates.addAll(dynamicTemplates);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
@@ -37,7 +37,12 @@ public class ECSProvisioningStrategy extends NodeProvisioner.Strategy {
         LoadStatistics.LoadStatisticsSnapshot snap = state.getSnapshot();
         Label label = state.getLabel();
 
-        int excessWorkload = snap.getQueueLength() - snap.getAvailableExecutors() - snap.getConnectingExecutors();
+        // plannedCapacitySnapshot covers nodes provisioned in a previous cycle whose
+        // ProvisioningCallback futures have not yet completed (not yet in Jenkins.getNodes()).
+        // Without this, a rapid event-triggered provisioner cycle can see those nodes as
+        // neither online nor offline and provision duplicates.
+        int excessWorkload = snap.getQueueLength() - snap.getAvailableExecutors() - snap.getConnectingExecutors()
+                - state.getPlannedCapacitySnapshot();
 
         // ECS agents use JNLP (the agent calls home to Jenkins), so they never appear in
         // connectingExecutors while the container is starting up. Without this adjustment,

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
@@ -1,8 +1,10 @@
 package com.cloudbees.jenkins.plugins.amazonecs;
 
 import hudson.Extension;
+import hudson.model.Computer;
 import hudson.model.Label;
 import hudson.model.LoadStatistics;
+import hudson.model.Node;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.slaves.Cloud;
 import hudson.slaves.CloudProvisioningListener;
@@ -36,6 +38,30 @@ public class ECSProvisioningStrategy extends NodeProvisioner.Strategy {
         Label label = state.getLabel();
 
         int excessWorkload = snap.getQueueLength() - snap.getAvailableExecutors() - snap.getConnectingExecutors();
+
+        // ECS agents use JNLP (the agent calls home to Jenkins), so they never appear in
+        // connectingExecutors while the container is starting up. Without this adjustment,
+        // every provisioner cycle that runs before the agent connects sees excessWorkload > 0
+        // and launches a duplicate task. We subtract offline ECS nodes matching this label
+        // to treat them as already-pending capacity.
+        // Note: failed agents are removed from Jenkins by ECSLauncher.launch()'s catch block
+        // (agent.terminate()), so they won't linger here indefinitely.
+        int pendingECSExecutors = 0;
+        if (label != null) {
+            for (Node node : Jenkins.get().getNodes()) {
+                if (node instanceof ECSSlave && label.matches(node)) {
+                    Computer c = node.toComputer();
+                    if (c != null && !c.isOnline()) {
+                        pendingECSExecutors += node.getNumExecutors();
+                    }
+                }
+            }
+        }
+        excessWorkload = Math.max(0, excessWorkload - pendingECSExecutors);
+        if (pendingECSExecutors > 0) {
+            LOGGER.log(Level.FINE, "Adjusting excess workload by {0} pending (offline) ECS executor(s); adjusted excessWorkload={1}",
+                    new Object[]{pendingECSExecutors, excessWorkload});
+        }
 
         CLOUD:
         for (Cloud c : Jenkins.get().clouds) {

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategyTest.java
@@ -1,0 +1,204 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import hudson.model.Label;
+import hudson.model.LoadStatistics;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.JNLPLauncher;
+import hudson.slaves.NodeProvisioner;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+
+/**
+ * Tests for {@link ECSProvisioningStrategy}, focusing on the pending-executor
+ * adjustment that prevents duplicate ECS tasks from being launched while a
+ * JNLP agent is starting up (issue #311).
+ *
+ * <p>ECS agents use JNLP (agent-initiated connection), so they are never
+ * counted in {@code connectingExecutors} by Jenkins' LoadStatistics while the
+ * container boots. Without the fix, every provisioner cycle that fires before
+ * the agent phones home would see {@code excessWorkload > 0} and launch
+ * another duplicate task. The strategy now subtracts offline ECSSlave nodes
+ * matching the requested label from {@code excessWorkload} to treat them as
+ * already-pending capacity.
+ */
+public class ECSProvisioningStrategyTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private ECSCloud makeCloud(String labelName) {
+        ECSCloud cloud = new ECSCloud("test-cloud", "", "", "test-cluster");
+        cloud.setTemplates(Collections.singletonList(makeTemplate(labelName)));
+        cloud.setRegionName("eu-west-1");
+        cloud.setNumExecutors(1);
+        cloud.setJenkinsUrl("http://jenkins.local");
+        cloud.setSlaveTimeoutInSeconds(5);
+        cloud.setRetentionTimeout(5);
+        return cloud;
+    }
+
+    private ECSTaskTemplate makeTemplate(String labelName) {
+        return new ECSTaskTemplate(
+                "template", labelName, "", "", null, "image",
+                "repositoryCredentials", "launchType", "operatingSystemFamily",
+                "cpuArchitecture", false, null, "networkMode", "remoteFSRoot",
+                false, null, 0, 0, 0, null, null, null, false, false,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, 0, false);
+    }
+
+    /**
+     * Creates a {@link NodeProvisioner.StrategyState} via reflection because
+     * its constructor is package-private in Jenkins core.
+     */
+    private NodeProvisioner.StrategyState createStrategyState(Label label, int queueLength)
+            throws Exception {
+        LoadStatistics.LoadStatisticsSnapshot snap =
+                LoadStatistics.LoadStatisticsSnapshot.builder()
+                        .withQueueLength(queueLength)
+                        .build();
+
+        Constructor<NodeProvisioner.StrategyState> ctor =
+                NodeProvisioner.StrategyState.class.getDeclaredConstructor(
+                        NodeProvisioner.class,
+                        LoadStatistics.LoadStatisticsSnapshot.class,
+                        Label.class,
+                        int.class);
+        ctor.setAccessible(true);
+        // label.nodeProvisioner is the NodeProvisioner associated with this label
+        return ctor.newInstance(label.nodeProvisioner, snap, label, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Baseline: when there are no offline ECS nodes the strategy should
+     * provision the workload normally and record planned capacity.
+     */
+    @Test
+    public void apply_noOfflineECSNodes_provisionsWhenWorkloadExists() throws Exception {
+        Label label = new LabelAtom("my-label");
+        j.jenkins.clouds.add(makeCloud("my-label"));
+
+        NodeProvisioner.StrategyState state = createStrategyState(label, 1);
+        new ECSProvisioningStrategy().apply(state);
+
+        Assert.assertTrue(
+                "Should have recorded planned capacity when no pending ECS nodes exist",
+                state.getAdditionalPlannedCapacity() > 0);
+    }
+
+    /**
+     * Core regression test for issue #311.
+     * An offline ECSSlave with a matching label represents a JNLP agent that
+     * has been created in Jenkins but has not yet phoned home.  The strategy
+     * must treat its executors as already-pending and must NOT provision an
+     * additional task.
+     */
+    @Test
+    public void apply_offlineECSNodeMatchingLabel_suppressesProvisioning() throws Exception {
+        Label label = new LabelAtom("my-label");
+        ECSCloud cloud = makeCloud("my-label");
+        j.jenkins.clouds.add(cloud);
+
+        // Simulate a JNLP agent that was provisioned but has not yet connected
+        ECSSlave pendingAgent = new ECSSlave(cloud, "pending-agent",
+                makeTemplate("my-label"), new JNLPLauncher());
+        j.jenkins.addNode(pendingAgent);   // offline by default (no JNLP channel)
+
+        NodeProvisioner.StrategyState state = createStrategyState(label, 1);
+        NodeProvisioner.StrategyDecision decision = new ECSProvisioningStrategy().apply(state);
+
+        Assert.assertEquals(
+                "Should return PROVISIONING_COMPLETED when pending node covers workload",
+                NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED, decision);
+        Assert.assertEquals(
+                "Should not provision additional tasks while a JNLP agent is starting up",
+                0, state.getAdditionalPlannedCapacity());
+    }
+
+    /**
+     * Label filter: an offline ECSSlave with a *different* label must not
+     * suppress provisioning for the requested label.
+     */
+    @Test
+    public void apply_offlineECSNodeDifferentLabel_provisionsNormally() throws Exception {
+        Label label = new LabelAtom("my-label");
+        ECSCloud cloud = makeCloud("my-label");
+        j.jenkins.clouds.add(cloud);
+
+        // Offline agent has a DIFFERENT label — should not count as pending
+        ECSSlave wrongLabelAgent = new ECSSlave(cloud, "wrong-label-agent",
+                makeTemplate("other-label"), new JNLPLauncher());
+        j.jenkins.addNode(wrongLabelAgent);
+
+        NodeProvisioner.StrategyState state = createStrategyState(label, 1);
+        new ECSProvisioningStrategy().apply(state);
+
+        Assert.assertTrue(
+                "Should provision when the only offline ECS node has a non-matching label",
+                state.getAdditionalPlannedCapacity() > 0);
+    }
+
+    /**
+     * Partial suppression: when queue depth exceeds the number of executors
+     * on pending offline nodes the strategy should provision only the
+     * remaining gap.
+     *
+     * <p>E.g. queue=2, one offline agent (1 executor) → gap of 1 → provisions 1 more.
+     */
+    @Test
+    public void apply_offlineECSNodeCoversPartOfWorkload_provisionsRemainder() throws Exception {
+        Label label = new LabelAtom("my-label");
+        ECSCloud cloud = makeCloud("my-label");
+        j.jenkins.clouds.add(cloud);
+
+        // One offline agent covers 1 of the 2 queued jobs
+        ECSSlave pendingAgent = new ECSSlave(cloud, "pending-agent",
+                makeTemplate("my-label"), new JNLPLauncher());
+        j.jenkins.addNode(pendingAgent);
+
+        // Queue length 2, one pending agent → remaining excess = 1
+        NodeProvisioner.StrategyState state = createStrategyState(label, 2);
+        new ECSProvisioningStrategy().apply(state);
+
+        Assert.assertEquals(
+                "Should provision exactly the remaining gap after accounting for pending node",
+                1, state.getAdditionalPlannedCapacity());
+    }
+
+    /**
+     * Multiple pending agents: two offline ECSSlaves with matching labels
+     * should fully suppress provisioning for a queue of two.
+     */
+    @Test
+    public void apply_multipleOfflineECSNodesCoversWorkload_suppressesProvisioning() throws Exception {
+        Label label = new LabelAtom("my-label");
+        ECSCloud cloud = makeCloud("my-label");
+        j.jenkins.clouds.add(cloud);
+
+        j.jenkins.addNode(new ECSSlave(cloud, "pending-agent-1",
+                makeTemplate("my-label"), new JNLPLauncher()));
+        j.jenkins.addNode(new ECSSlave(cloud, "pending-agent-2",
+                makeTemplate("my-label"), new JNLPLauncher()));
+
+        NodeProvisioner.StrategyState state = createStrategyState(label, 2);
+        NodeProvisioner.StrategyDecision decision = new ECSProvisioningStrategy().apply(state);
+
+        Assert.assertEquals(NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED, decision);
+        Assert.assertEquals(
+                "Two offline agents should suppress provisioning for a queue of two",
+                0, state.getAdditionalPlannedCapacity());
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategyTest.java
@@ -62,6 +62,11 @@ public class ECSProvisioningStrategyTest {
      */
     private NodeProvisioner.StrategyState createStrategyState(Label label, int queueLength)
             throws Exception {
+        return createStrategyState(label, queueLength, 0);
+    }
+
+    private NodeProvisioner.StrategyState createStrategyState(Label label, int queueLength, int plannedCapacity)
+            throws Exception {
         LoadStatistics.LoadStatisticsSnapshot snap =
                 LoadStatistics.LoadStatisticsSnapshot.builder()
                         .withQueueLength(queueLength)
@@ -74,8 +79,7 @@ public class ECSProvisioningStrategyTest {
                         Label.class,
                         int.class);
         ctor.setAccessible(true);
-        // label.nodeProvisioner is the NodeProvisioner associated with this label
-        return ctor.newInstance(label.nodeProvisioner, snap, label, 0);
+        return ctor.newInstance(label.nodeProvisioner, snap, label, plannedCapacity);
     }
 
     // -----------------------------------------------------------------------
@@ -176,6 +180,30 @@ public class ECSProvisioningStrategyTest {
         Assert.assertEquals(
                 "Should provision exactly the remaining gap after accounting for pending node",
                 1, state.getAdditionalPlannedCapacity());
+    }
+
+    /**
+     * plannedCapacitySnapshot covers nodes provisioned in a previous cycle whose
+     * ProvisioningCallback futures have not yet completed (not yet in Jenkins.getNodes()).
+     * The strategy must subtract this from excessWorkload to avoid launching duplicates
+     * when the provisioner is triggered again before those futures resolve.
+     */
+    @Test
+    public void apply_plannedCapacityFromPreviousCycle_suppressesProvisioning() throws Exception {
+        Label label = new LabelAtom("my-label");
+        j.jenkins.clouds.add(makeCloud("my-label"));
+
+        // Simulate 1 job queued, 1 agent already planned in a previous cycle
+        // (its ProvisioningCallback future not yet done → not in Jenkins.getNodes())
+        NodeProvisioner.StrategyState state = createStrategyState(label, 1, 1);
+        NodeProvisioner.StrategyDecision decision = new ECSProvisioningStrategy().apply(state);
+
+        Assert.assertEquals(
+                "Should return PROVISIONING_COMPLETED when plannedCapacitySnapshot covers workload",
+                NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED, decision);
+        Assert.assertEquals(
+                "Should not provision additional tasks when previous cycle already planned enough",
+                0, state.getAdditionalPlannedCapacity());
     }
 
     /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

ECS agents use JNLP (agent-initiated connection), so they are invisible to Jenkins' `connectingExecutors` metric while the container is starting up. 
This creates a gap: once the `PlannedNode` future resolves (nearly instantly after `ProvisioningCallback` returns the `ECSSlave`), the node is removed from `pendingLaunches` but isn't yet online. 
Every subsequent `ECSProvisioningStrategy` cycle - which fires every 10 seconds - sees `excessWorkload > 0` and launches another duplicate ECS task.

The fix accounts for offline `ECSSlave` nodes matching the requested label as already-pending capacity, subtracting their executors from `excessWorkload` before the provisioning loop. 
Failed agents are cleaned up by `ECSLauncher.launch()`'s catch block (`agent.terminate()`), so they don't linger as false pending capacity.

Fixes #311, #416

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

5 automated tests added in `ECSProvisioningStrategyTest` covering:

| Test | Scenario |
|---|---|
| `noOfflineECSNodes_provisionsWhenWorkloadExists` | Baseline: no pending nodes → provisions normally |
| `offlineECSNodeMatchingLabel_suppressesProvisioning` | Core fix: offline ECS node with matching label suppresses duplicate provision |
| `offlineECSNodeDifferentLabel_provisionsNormally` | Label filter: wrong-label offline node does not suppress provisioning |
| `offlineECSNodeCoversPartOfWorkload_provisionsRemainder` | Partial suppression: pending node covers part of queue, remainder is provisioned |
| `multipleOfflineECSNodesCoversWorkload_suppressesProvisioning` | Multiple pending nodes fully absorb workload |

All 43 tests pass on Java 21 (`BUILD SUCCESS`, 3 pre-existing `@Ignore` skips in `ECSServiceTest`).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md
You can override it by creating .github/pull_request_template.md in your own repository
-->
